### PR TITLE
Refactor Binary Expression Parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -140,7 +140,7 @@ var binaryOperatorParser = parser.regex(binaryOperatorRegex)
 var binaryExprParser = src => {
   var biExpr = estemplate.binaryExpression
   let result = parser.all(
-                          expressionParser,
+                          parser.any(fnCallParser, expressionParser),
                           spaceParser,
                           binaryOperatorParser,
                           spaceParser,
@@ -187,21 +187,19 @@ var binaryExprParser = src => {
                remaining]
   }
 
-  if (precedence(nextOperator) === precedence(firstOperator)) {
-    return associativity(firstOperator) === 'R'
-            ? [
+  return associativity(firstOperator) === 'R'
+          ? [
+            biExpr(
+              leftOperand,
+              firstOperator,
+              biExpr(rightOperand, nextOperator, nextExpr)),
+            remaining]
+            : [
               biExpr(
-                leftOperand,
-                firstOperator,
-                biExpr(rightOperand, nextOperator, nextExpr)),
+                biExpr(leftOperand, firstOperator, rightOperand),
+                nextOperator,
+                nextExpr),
               remaining]
-              : [
-                biExpr(
-                  biExpr(leftOperand, firstOperator, rightOperand),
-                  nextOperator,
-                  nextExpr),
-                remaining]
-  }
 }
 
 var declParser = parser.bind(


### PR DESCRIPTION
1. Adds check for a function call in the first part of a binary expression.
2. Removes redundant 'if' statement which handled the case of two operators of having equal precedence. 