### PR TITLE
Add Unary Expression Parser and Unary Expression Template

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -64,6 +64,13 @@ estemplate.letExpression = (...val) => (
   }
 )
 
+estemplate.memberParser = (obj, prop) => (
+  {
+    obj: obj,
+    prop: prop
+  }
+)
+
 estemplate.fnCall = (val, args) => {
   return {
     type: 'ExpressionStatement',
@@ -98,5 +105,13 @@ estemplate.binaryExpression = (left, op, right) => {
   }
 }
 
+estemplate.unaryExpression = (op, arg) => (
+  {
+    'type': 'UnaryExpression',
+    'operator': op,
+    'argument': arg,
+    'prefix': true
+  }
+)
 /*  Module Exports estemplate  */
 module.exports = estemplate

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -22,12 +22,14 @@ const lookAhead = src => {
 
 /*  Predifined regexes */
 const idRegex = /^([a-zA-Z]+[a-zA-Z0-9_]*)((.|\n)*)$/
-const numRegex = /^([\-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[e][+\-]?\d+)?)((.|\n)*)$/
+const numRegex = /^([-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[e][+-]?\d+)?)((.|\n)*)$/
 const boolRegex = /^(true|false)((.|\n)*)$/i
-const stringRegex = /^(\'[^\\']*(?:\\.[^\\']*)*\')((.|\n)*)$/
+const stringRegex = /^('[^\\']*(?:\\.[^\\']*)*')((.|\n)*)$/
 // var argsRegex = /^([^=]*)((.|\n)*)$/
-const binaryOperatorRegex = /^(\+|\-|\/|\*|\<\<|\<\=|\<|\>\>\>|\>\>|\>\=|\>|\&\&|\&|\|\||\||\^|\=\=)(?=\s)((.|\n)*)$/
+const binaryOperatorRegex = /^(\+|-|\/|\*|<<|<=|<|>>>|>>|>=|>|&&|&|\|\||\||\^|==)(?=\s)((.|\n)*)$/
 // var nullRegEx       = /^null\b/i
+const unaryOperatorRegex = /^(:type|-|!)((.|\n)*)$/
+ // /^(:type(?=\s)|(-|!)(?!\s))((.|\n)*)$/
 
 /*
   Parser factory. Used to create parsers
@@ -136,6 +138,27 @@ var paramsParser = (str, paramArray = []) => {
 }
 
 var expressionParser = parser.any(parenthesisParser, booleanParser, identifierParser, numberParser)
+
+var unaryOperatorParser = parser.regex(unaryOperatorRegex)
+
+var unaryExpressionParser = (src) => {
+  let unaryExpr = estemplate.unaryExpression
+  let match = unaryOperatorParser(src)
+  if (match === null) return null
+  let [operator, possibleArg] = match
+
+  if (operator === ':type' && possibleArg[0] === ' ') {
+    [operator, possibleArg] = ['typeof', spaceParser(possibleArg)[1]]
+  }
+
+  let [arg, rest] = expressionParser(possibleArg) === null
+                    ? [null, possibleArg]
+                    : expressionParser(possibleArg)
+
+  return arg !== null
+    ? [unaryExpr(operator, arg.type === 'ExpressionStatement' ? arg.expression : arg), rest]
+    : null
+}
 
 var binaryOperatorParser = parser.regex(binaryOperatorRegex)
 


### PR DESCRIPTION
In `lib/parser.js` : 
1. Add Unary Expression Parser, Unary Operator RegEx.
2. Remove unnecessary `\`'s from `binaryOperatorRegex`, `numRegex` and `stringRegex`

In `lib/estemplate.js` : 
1. Add template for Unary Expressions