### PR TITLE
Fix for nested if statements

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -147,7 +147,7 @@ var parenthesisParser = parser.bind(
       return space ? [space[0], space[1]] : [null, input]
     }),
     val => input => mayBe(
-      parser.any(binaryExprParser, fnCallParser, expressionParser, unaryExprParser)(input),
+      parser.any(ifExprParser, binaryExprParser, fnCallParser, expressionParser, unaryExprParser)(input),
       (v, rest) => returnRest(v, input, rest.str)
     )),
     val => input => {
@@ -356,7 +356,7 @@ var ifExprParser = input => mayBe(
     spaceParser, thenParser, expressionParser,
     spaceParser, elseParser, expressionParser)(input),
     (val, rest) => {
-      let [, condition, , , consequent, , , alternate] = val
+      let [, condition, , , consequent, , , alternate] = val.map(ex => ex.type === 'ExpressionStatement' ? ex.expression : ex)
       return returnRest(estemplate.ifthenelse(condition, consequent, alternate), input, rest.str)
     }
 )


### PR DESCRIPTION
- Add `ifExprParser` to `parenthesisParser`
- Extract expression from expression statement wrapper.