### PR TITLE
Extract expressions from `ExpressionStatement` wrapper

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -1,6 +1,8 @@
 const types = require('./operatorPrecedence')
 let estemplate = {}
 
+const extractExpr = token => token.type === 'ExpressionStatement' ? token.expression : token
+
 estemplate.error = msg => (
   {
     'interrupt': true,
@@ -79,7 +81,7 @@ estemplate.declaration = (id, val) => {
       {
         type: 'VariableDeclarator',
         id: id,
-        init: val
+        init: extractExpr(val)
       }
     ],
     kind: 'const'
@@ -130,12 +132,12 @@ estemplate.memberExpression = (obj, prop) =>
       type: 'MemberExpression',
       computed: false,
       object: obj,
-      property: prop
+      property: extractExpr(prop)
     }
   })
 
 estemplate.fnCall = (val, args) =>
-  ({type: 'CallExpression', callee: val, arguments: args})
+  ({type: 'CallExpression', callee: val, arguments: args.map(arg => extractExpr(arg))})
 
 estemplate.lambda = (...val) =>
   ({
@@ -144,7 +146,7 @@ estemplate.lambda = (...val) =>
       type: 'ArrowFunctionExpression',
       id: null,
       params: val[0],
-      body: val[1] || '',
+      body: extractExpr(val[1]) || '',
       generator: false,
       expression: true
     }
@@ -160,8 +162,8 @@ estemplate.binaryExpression = (left, op, right, line) => {
       type: 'BinaryExpression',
       operator: op === '==' ? '===' : op,
       sType: opType === 'all' ? 'bool' : opType,
-      left: left,
-      right: right
+      left: extractExpr(left),
+      right: extractExpr(right)
     })
   }
   return estemplate.error(`Type Error at line: ${line}`)
@@ -183,7 +185,7 @@ estemplate.printexpression = (args) => ({
         'name': 'log'
       }
     },
-    'arguments': args
+    'arguments': args.map(arg => extractExpr(arg))
   }
 })
 
@@ -191,7 +193,7 @@ estemplate.unaryExpression = (op, arg) => (
   {
     type: 'UnaryExpression',
     operator: op,
-    argument: arg,
+    argument: extractExpr(arg),
     prefix: true
   }
 )
@@ -205,9 +207,9 @@ estemplate.ifthenelse = (condition, result1, result2) => ({
   'type': 'ExpressionStatement',
   'expression': {
     'type': 'ConditionalExpression',
-    'test': condition,
-    'consequent': result1,
-    'alternate': result2
+    'test': extractExpr(condition),
+    'consequent': extractExpr(result1),
+    'alternate': extractExpr(result2)
   }
 })
 /*  Module Exports estempla[te  */

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -189,9 +189,7 @@ var declParser = parser.bind(
   val => input => mayBe(
         parser.any(ifExprParser, binaryExprParser, fnCallParser, expressionParser, unaryExprParser)(input),
         (v, rest) => {
-          return v.type !== undefined && v.type === 'ExpressionStatement'
-              ? returnRest(estemplate.declaration(val, v.expression), input, rest.str)
-              : returnRest(estemplate.declaration(val, v), input, rest.str)
+          return returnRest(estemplate.declaration(val, v), input, rest.str)
         }
       )
 )
@@ -327,7 +325,6 @@ var argsParser = (input, argArray = []) => {
     newLineFlag = 1
   }
   if (binaryOperatorRegex.exec(arg[1].str) !== null) arg[1].str = ' ' + arg[1].str
-  if (arg[0].type === 'ExpressionStatement') arg[0] = arg[0].expression
   if (newLineFlag) return [argArray.concat(arg[0]), arg[1]]
   return argsParser(arg[1], argArray.concat(arg[0]))
 }
@@ -344,9 +341,7 @@ var fnCallParser = parser.bind(
   parser.all(parser.any(memberPropsParser, identifierParser), spaceParser),
   val => input => mayBe(
       argsParser(input),
-      (args, rest) => val[1] === 'n' ? null : val[0].type === 'ExpressionStatement'
-      ? returnRest(estemplate.fnCall(val[0].expression, args), input, rest.str)
-      : returnRest(estemplate.fnCall(val[0], args), input, rest.str)
+      (args, rest) => val[1] === 'n' ? null : returnRest(estemplate.fnCall(val[0], args), input, rest.str)
     )
 )
 
@@ -356,7 +351,7 @@ var ifExprParser = input => mayBe(
     spaceParser, thenParser, expressionParser,
     spaceParser, elseParser, expressionParser)(input),
     (val, rest) => {
-      let [, condition, , , consequent, , , alternate] = val.map(ex => ex.type === 'ExpressionStatement' ? ex.expression : ex)
+      let [, condition, , , consequent, , , alternate] = val
       return returnRest(estemplate.ifthenelse(condition, consequent, alternate), input, rest.str)
     }
 )


### PR DESCRIPTION
- [in lib/estemplate.js]
1. Check for wrapped expressions in the following:
	-- constant declaration
	-- function call
	-- member expression
	-- lambda expression
	-- print expression
	-- unary expression
	-- binary expression

2. add extractExpr function

- [in lib/parser.js]
1. Remove checks for `ExpressionStatement`

This removes semicolons at unwanted places