### PR TITLE
Remove `printParser`

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -133,8 +133,8 @@ estemplate.memberExpression = (obj, prop) =>
     }
   })
 
-estemplate.fnCall = (val, args) =>
-  ({type: 'CallExpression', callee: val, arguments: args.map(arg => extractExpr(arg))})
+estemplate.fnCall = (val, args) => val.name === 'print' ? estemplate.printexpression(args)
+  : ({type: 'CallExpression', callee: val, arguments: args.map(arg => extractExpr(arg))})
 
 estemplate.lambda = (...val) =>
   ({

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -100,8 +100,6 @@ var inParser = parser.regex(/^(\s*in\s+)((.|\n)*)$/)
 
 var dotParser = parser.regex(/^(\.)((.|\n)*)$/)
 
-var prntParser = parser.regex(/^(print\s+)((.|\n)*)$/)
-
 var ifParser = parser.regex(/^(if\s+)((.|\n)*)$/)
 var thenParser = parser.regex(/^(then\s+)((.|\n)*)$/)
 var elseParser = parser.regex(/^(else\s+)((.|\n)*)$/)
@@ -323,14 +321,6 @@ var argsParser = (input, argArray = []) => {
   return argsParser(rest, argArray.concat(argument))
 }
 
-var printParser = parser.bind(
-    prntParser,
-    val => input => mayBe(
-      argsParser(input),
-      (args, rest) => returnRest(estemplate.printexpression(args), input, rest.str)
-    )
-)
-
 var fnCallParser = parser.bind(
   parser.all(parser.any(memberPropsParser, identifierParser), spaceParser),
   val => input => mayBe(
@@ -358,7 +348,7 @@ var multiLineParser = src => {
   return multiLineParser(src)
 }
 
-var statementParser = parser.any(returnParser, printParser, letExpressionParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser)
+var statementParser = parser.any(returnParser, letExpressionParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser)
 
 var programParser = (input, ast = estemplate.ast()) => {
   let result = statementParser(returnRest('', input, multiLineParser(input.str.split('\n')).join('\n'))[1])


### PR DESCRIPTION
[in lib/estemplate.js]
 - Check for `print` in `fnCall` template and replace with
 `printexpression` template

[in lib/parser.js]
 - Remove `printParser` method and `prntParser` regex

Redundant code as both `fnCall` and `print` are similar.