### PR TITLE
Add type inference for recursive functions

### DIFF
--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -25,7 +25,7 @@ const statementType = expr => {
   }
 }
 
-const exprType = (expr, localTypeObj = {}) => {
+const exprType = (expr, localTypeObj = {}, id = null) => {
   let type = expr.type
   switch (type) {
     case 'Literal':
@@ -41,9 +41,13 @@ const exprType = (expr, localTypeObj = {}) => {
     case 'ConditionalExpression':
       return conditionalExprType(expr)
     case 'ArrowFunctionExpression':
-      return arrowFunctionExprType(expr)
+      return arrowFunctionExprType(expr, localTypeObj, id)
     case 'MemberExpression':
       return memberExprType(expr, localTypeObj)
+    case 'BlockStatement':
+      return blockStatementType(expr, localTypeObj, id)
+    case 'SwitchStatement':
+      return switchStatementType(expr, localTypeObj, id)
     default:
       return expr
   }
@@ -104,20 +108,20 @@ const makeParamTypeArray = (localTypeObj) => {
   return paramTypes
 }
 
-const arrowFunctionExprType = expr => {
+const arrowFunctionExprType = (expr, localTypeObj, id) => {
   let [params, body] = [expr.params, expr.body]
-  let localTypeObj = {}
   params.map(param => { localTypeObj[param.name] = 'needsInference' })
-  let returnType = exprType(body, localTypeObj)
-  return {type: 'function', paramTypes: makeParamTypeArray(localTypeObj), returnType}
+  let returnType = exprType(body, localTypeObj, id)
+  return returnType === null ? null : {type: 'function', paramTypes: makeParamTypeArray(localTypeObj), returnType}
 }
 
-const matchArgTypesToAcceptedTypes = (args, acceptedTypes) => args
-      .map((arg, index) => exprType(arg) === acceptedTypes[index])
-      .reduce((type1, type2) => type1 === type2)
+const matchArgTypesToAcceptedTypes = (args, acceptedTypes, localTypeObj) => args.map(
+  (arg, index) => exprType(arg, localTypeObj) === acceptedTypes[index])
+  .reduce((type1, type2) => type1 === type2)
 
 const callExprType = (expr, localTypeObj = {}) => {
   let [params, body, args] = [expr.callee.params, expr.callee.body, expr.arguments]
+
   if (params !== undefined && body !== undefined && !(isEmpty(localTypeObj))) {
     let typesOfParams = mapArgTypeToParams(params, args)
     params.map((param, index) => {
@@ -126,21 +130,49 @@ const callExprType = (expr, localTypeObj = {}) => {
     })
     return exprType(body, localTypeObj)
   }
-  let [acceptedTypes, returnType] = exprType(expr.callee, localTypeObj)
-  return matchArgTypesToAcceptedTypes(args, acceptedTypes) ? returnType : null
-}
 
+  let [acceptedTypes, returnType] = exprType(expr.callee, localTypeObj)
+  return matchArgTypesToAcceptedTypes(args, acceptedTypes, localTypeObj) ? returnType : null
+}
 // TODO
 // const memberExprType = (expr, localTypeObj) => {
-//   let id = expr.object
-//   return exprType(id, localTypeObj)
+//   return expr
 // }
+
+const reduceTypes = (typesArr, localTypeObj) => (
+  typesArr.map(e => exprType(e, localTypeObj))
+          .reduce((type1, type2) => type1 === type2 ? type1 : false))
+
+const switchStatementType = (body, localTypeObj, id) => {
+  let cases = body.cases
+  let [initialPattern] = cases
+
+  let [returnType, acceptedType] = [
+    initialPattern.consequent[0].argument,
+    initialPattern.test].map(e => exprType(e, localTypeObj))
+
+  let paramId = body.discriminant.name
+
+  localTypeObj[paramId] = acceptedType
+  globalTypesObj[id] = {type: 'function', paramTypes: makeParamTypeArray(localTypeObj), returnType}
+  let [caseArgArray, caseTestArray] = [
+    cases.map(c => c.consequent[0].argument),
+    cases.map(c => c.test === null ? {type: 'Identifier', name: paramId, sType: acceptedType} : c.test)]
+
+  if (reduceTypes(caseArgArray, localTypeObj) === false || reduceTypes(caseTestArray, localTypeObj) === false) return null
+  return returnType
+}
+
+const blockStatementType = (stmnt, localTypeObj, id) => {
+  let [expr] = stmnt.body
+  return exprType(expr, localTypeObj, id)
+}
 
 const declTypeExtract = stmnt => {
   let [decl] = stmnt.declarations
-  let [id, exp] = [decl.id, decl.init]
-  let type = exprType(exp)
-  globalTypesObj[id.name] = type
+  let [id, exp] = [decl.id.name, decl.init]
+  let type = exprType(exp, {}, id)
+  globalTypesObj[id] = type
 }
 
 const types = body => {


### PR DESCRIPTION
- Fixes #39 
- pass the variable id along to exprType
- add method to extract expressions of blockStatements
- add method to extract expressions of switchCase statements (for recursive functions)