### PR TITLE
Add support for `arraySubscriptExpressions`

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -145,6 +145,17 @@ estemplate.memberExpression = (obj, prop) =>
     }
   })
 
+estemplate.arraySubscriptExpression = (obj, prop) =>
+  ({
+    type: 'ExpressionStatement',
+    expression: {
+      type: 'MemberExpression',
+      computed: true,
+      object: obj,
+      property: extractExpr(prop)
+    }
+  })
+
 estemplate.fnCall = (val, args) => val.name === 'print' ? estemplate.printexpression(args)
   : ({type: 'CallExpression', callee: extractExpr(val), arguments: args.map(arg => extractExpr(arg))})
 

--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -151,7 +151,7 @@ estemplate.arraySubscriptExpression = (obj, prop) =>
     expression: {
       type: 'MemberExpression',
       computed: true,
-      object: obj,
+      object: extractExpr(obj),
       property: extractExpr(prop)
     }
   })

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -518,7 +518,7 @@ const arrayElemsParser = (input, propArr = []) => {
   let result = arrayElemParser(input)
 
   if (result === null) {
-    return commaCheck(result, propArr)
+    return commaCheck(input, propArr)
   }
 
   if (result === null) return [propArr, input]

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -195,7 +195,7 @@ const parenthesisParser = parser.bind(
       : null
 )
 
-const expressionParser = input => parser.any(parenthesisParser, booleanParser, identifierParser, numberParser, stringParser)(input)
+const expressionParser = input => parser.any(memberExprParser, arraySubscriptParser, arrayParser, objectParser, parenthesisParser, booleanParser, identifierParser, numberParser, stringParser)(input)
 
 const unaryOperatorParser = input => mayBe(
     unaryOperatorRegex.exec(input.str),
@@ -295,7 +295,7 @@ const lambdaParser = parser.bind(
    )
  )
 
-const letParamParser = input => parser.all(expressionParser, equalSignParser, parser.any(objectParser, expressionParser), spaceParser)(input)
+const letParamParser = input => parser.all(expressionParser, equalSignParser, expressionParser, spaceParser)(input)
 
 const letParamsParser = (str, letIdArray = [], letLiteralArray = []) => {
   let param = letParamParser(str)
@@ -329,11 +329,12 @@ const letExpressionParser = parser.bind(
     )
   )
 
-const memberPropParser = input => parser.all(identifierParser, dotParser)(input)
+const memberPropParser = input => parser.all(
+  parser.any(arrayParser, arraySubscriptParser, identifierParser)
+  , dotParser)(input)
 
 const memberExprParser = (str, memberArray = []) => {
   let result = memberPropParser(str)
-
   if (result !== null) {
     let [[val], rest] = result
     return memberExprParser(rest, memberArray.concat(val))
@@ -341,10 +342,11 @@ const memberExprParser = (str, memberArray = []) => {
 
   if (result === null && memberArray.length === 0) return null
 
-  let property = identifierParser(str)
+  let property = parser.any(arraySubscriptParser, identifierParser)(str)
   if (property === null) return null
 
   let [val, rest] = property
+
   let tree = memberExprGenerator(memberArray.concat(val))
   return [tree, rest]
 }
@@ -357,6 +359,27 @@ const memberExprGenerator = (input, tree = {}) => {
     tree = memExpr(tree.expression, input[i])
   }
   return tree
+}
+
+const subscriptParser = input => parser.all(
+  openSquareBracketParser,
+  parser.any(memberExprParser, arraySubscriptParser, identifierParser, numberParser, stringParser),
+  closeSquareBracketParser)(input)
+
+const formNestedExpression = (prevObj, rest) => {
+  if (subscriptParser(rest) === null) return returnRest(prevObj, rest, rest.str)
+  let [[, prop], _rest] = subscriptParser(rest)
+  return formNestedExpression(estemplate.arraySubscriptExpression(prevObj, prop), _rest)
+}
+const arraySubscriptParser = input => {
+  let result = parser.all(identifierParser, subscriptParser)(input)
+  if (result === null) return null
+  let [[obj, [, prop]], rest] = result
+  let firstExp = estemplate.arraySubscriptExpression(obj, prop)
+
+  let nestedExpr = formNestedExpression(firstExp, rest)
+  if (nestedExpr === null) return returnRest(firstExp, input, rest.str)
+  return nestedExpr
 }
 
 const argsParser = (input, argArray = []) => {


### PR DESCRIPTION
In `lib/parser.js`:
- add `arraySubscriptParser`
- fix `arrayElemsParser`

In `lib/estemplate.js`:
- add `arraySubscriptExpression`
- fix `arraySubscriptExpression`