### PR TITLE
Fix 'commaCheck'

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -511,7 +511,7 @@ const commaCheck = (input, propArr) => {
     let [, rest] = comma
     return arrayElemsParser(rest, propArr)
   }
-  return [propArr, input]
+  return [propArr, rest]
 }
 
 const arrayElemsParser = (input, propArr = []) => {


### PR DESCRIPTION
return 'rest' instead of 'input'