### PR TITLE
Fix for escape sequences in strings

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -130,9 +130,11 @@ const identifierParser = input => mayBe(
   (a, name, rest) => returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
 )
 
+const unescape = str => str.replace(/(^')/, '').replace(/('$)/, '').replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\r/g, '\r').replace(/\\'/g, '\'')
+
 const stringParser = input => mayBe(
   stringRegex.exec(input.str),
-  (a, string, rest) => returnRest(estemplate.stringLiteral(string.replace(/(^')/, '').replace(/('$)/, '')),
+  (a, string, rest) => returnRest(estemplate.stringLiteral(unescape(string)),
                                     input, rest, {'name': 'column', 'value': string.length})
 )
 


### PR DESCRIPTION
Replace `\\n`, `\\t`, `\\r`, `\\'` with `\n`, `\t`, `\r`, `\'`

Resolve #68 