### PR TITLE
Type inference for `member expressions`

### DIFF
--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -4,6 +4,7 @@ const globalTypesObj = {}
 const getType = (expr, expectedType, localTypeObj) => {
   if (expr !== undefined) {
     let type = exprType(expr, localTypeObj)
+    type = type === 'any' ? expectedType : type
     return type === expectedType || expectedType === 'bool' ? type : null
   }
 }
@@ -51,6 +52,8 @@ const exprType = (expr, localTypeObj = {}, id = null) => {
       return blockStatementType(expr, localTypeObj, id)
     case 'SwitchStatement':
       return switchStatementType(expr, localTypeObj, id)
+    case 'ArrayExpression':
+      return arrayExprType(expr, localTypeObj)
     default:
       return expr
   }
@@ -62,12 +65,19 @@ const isFunction = (id, typeObj) => typeObj[id] !== undefined && typeObj[id].typ
 
 const getParamReturnTypes = (id, typeObj) => [typeObj[id.name].paramTypes, typeObj[id.name].returnType]
 
-const returnIdentifierType = (id, typeObj) => isFunction(id.name, typeObj) ? getParamReturnTypes(id, typeObj) : typeObj[id.name]
+const isArray = (id, typeObj) => typeObj[id] !== undefined && typeObj[id].type === 'array'
 
-const identifierType = (id, localTypeObj) => (
-    localTypeObj[id.name] !== undefined ? returnIdentifierType(id, localTypeObj)
-    : globalTypesObj[id.name] !== undefined ? returnIdentifierType(id, globalTypesObj)
-    : null)
+const returnIdentifierType = (id, typeObj) => {
+  if (isFunction(id.name, typeObj)) return getParamReturnTypes(id, typeObj)
+  if (isArray(id.name, typeObj)) return typeObj[id.name].elemTypes
+  return typeObj[id.name]
+}
+
+const identifierType = (id, localTypeObj) => {
+  if (localTypeObj[id.name] !== undefined) return returnIdentifierType(id, localTypeObj)
+  if (globalTypesObj[id.name] !== undefined) return returnIdentifierType(id, globalTypesObj)
+  return null
+}
 
 const unaryExprType = expr => {
   if (expr.operator === 'typeof') return 'string'
@@ -137,10 +147,8 @@ const callExprType = (expr, localTypeObj = {}) => {
   let [acceptedTypes, returnType] = exprType(expr.callee, localTypeObj)
   return matchArgTypesToAcceptedTypes(args, acceptedTypes, localTypeObj) ? returnType : null
 }
-// TODO
-// const memberExprType = (expr, localTypeObj) => {
-//   return expr
-// }
+
+const memberExprType = (expr, localTypeObj) => 'any'
 
 const reduceTypes = (typesArr, localTypeObj) => (
   typesArr.map(e => exprType(e, localTypeObj))
@@ -164,6 +172,12 @@ const switchStatementType = (body, localTypeObj, id) => {
 
   if (reduceTypes(caseArgArray, localTypeObj) === false || reduceTypes(caseTestArray, localTypeObj) === false) return null
   return returnType
+}
+
+const arrayExprType = (expr, localTypeObj) => {
+  let arrayTypeObj = {}
+  expr.elements.map((e, index) => { arrayTypeObj[index] = exprType(e, localTypeObj) })
+  return {'type': 'array', 'elemTypes': arrayTypeObj}
 }
 
 const blockStatementType = (stmnt, localTypeObj, id) => {


### PR DESCRIPTION
Introduce `any` type for `member expressions`