### PR TITLE
Fix `let` expressions being taken as function calls

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -225,7 +225,7 @@ const declParser = parser.bind(
       )
   ),
   val => input => mayBe(
-    parser.any(fnCallParser, memberExprParser, arrayParser, objectParser, unaryExprParser, letExpressionParser, ifExprParser, binaryExprParser, expressionParser)(input),
+    parser.any(unaryExprParser, letExpressionParser, ifExprParser, binaryExprParser, fnCallParser, memberExprParser, arrayParser, objectParser, expressionParser)(input),
         (v, rest) => {
           return returnRest(estemplate.declaration(val, v), input, rest.str)
         }


### PR DESCRIPTION
Change the order of parsing