### PR TITLE
Remove `arraySubscriptParser` and `formNestedExpression`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -197,7 +197,7 @@ const parenthesisParser = parser.bind(
       : null
 )
 
-const expressionParser = input => parser.any(memberExprParser, arraySubscriptParser, arrayParser, objectParser, parenthesisParser, booleanParser, identifierParser, numberParser, stringParser)(input)
+const expressionParser = input => parser.any(memberExprParser, arrayParser, objectParser, parenthesisParser, booleanParser, identifierParser, numberParser, stringParser)(input)
 
 const unaryOperatorParser = input => mayBe(
     unaryOperatorRegex.exec(input.str),
@@ -356,7 +356,7 @@ const memberExprParser = input => {
 const subscriptParser = input => {
   let result = parser.all(
   openSquareBracketParser,
-  parser.any(memberExprParser, arraySubscriptParser, identifierParser, numberParser, stringParser),
+  parser.any(memberExprParser, identifierParser, numberParser, stringParser),
     closeSquareBracketParser)(input)
   if (result !== null) {
     let [[, prop], rest] = result
@@ -364,21 +364,6 @@ const subscriptParser = input => {
     return returnRest(prop, input, rest.str)
   }
   return null
-}
-
-const formNestedExpression = (prevObj, rest) => {
-  if (subscriptParser(rest) === null) return returnRest(prevObj, rest, rest.str)
-  let [prop, _rest] = subscriptParser(rest)
-  return formNestedExpression(estemplate.subscriptExpression(prevObj, prop), _rest)
-}
-const arraySubscriptParser = input => {
-  let result = parser.all(parser.any(memberExprParser, identifierParser), subscriptParser)(input)
-  if (result === null) return null
-  let [[obj, prop], rest] = result
-  let firstExp = estemplate.subscriptExpression(obj, prop)
-  let nestedExpr = formNestedExpression(firstExp, rest)
-  if (nestedExpr === null) return returnRest(firstExp, input, rest.str)
-  return nestedExpr
 }
 
 const argsParser = (input, argArray = []) => {


### PR DESCRIPTION
`memberExprParser` handles all types of `member expressions`