### PR TITLE
Extract `CallExpression` from `ExpressionStatement` wrapper

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -90,25 +90,25 @@ estemplate.declaration = (id, val) => ({
   declarations: [
     {
       type: 'VariableDeclarator',
-      id: id,
+      id,
       init: extractExpr(val)
     }
   ],
   kind: 'const'
 })
 
-estemplate.funcDeclaration = (...val) =>
+estemplate.funcDeclaration = (id, params, body) =>
   ({
     type: 'VariableDeclaration',
     declarations: [
       {
         type: 'VariableDeclarator',
-        id: val[0],
+        id,
         init: {
           type: 'ArrowFunctionExpression',
           id: null,
-          params: val[1],
-          body: val[2] || '',
+          params: params,
+          body: extractExpr(body) || '',
           generator: false,
           expression: true
         }
@@ -117,22 +117,20 @@ estemplate.funcDeclaration = (...val) =>
     kind: 'const'
   })
 
-estemplate.letExpression = (...val) =>
+estemplate.letExpression = (params, args, body) =>
   ({
-    type: 'ExpressionStatement',
-    expression: {
-      type: 'CallExpression',
-      callee: {
-        'type': 'ArrowFunctionExpression',
-        id: null,
-        params: val[0],
-        body: val[2] || '',
-        generator: false,
-        expression: true
-      },
-      arguments: val[1]
-    }
-  })
+    type: 'CallExpression',
+    callee: {
+      'type': 'ArrowFunctionExpression',
+      id: null,
+      params: params,
+      body: extractExpr(body) || '',
+      generator: false,
+      expression: true
+    },
+    arguments: args.map(extractExpr)
+  }
+  )
 
 estemplate.memberExpression = (obj, prop) =>
   ({
@@ -157,7 +155,7 @@ estemplate.subscriptExpression = (obj, prop) =>
   })
 
 estemplate.fnCall = (val, args) => val.name === 'print' ? estemplate.printexpression(args)
-  : ({type: 'CallExpression', callee: extractExpr(val), arguments: args.map(arg => extractExpr(arg))})
+  : ({type: 'CallExpression', callee: extractExpr(val), arguments: args.map(extractExpr)})
 
 estemplate.lambda = (...val) =>
   ({
@@ -236,14 +234,14 @@ estemplate.array = elements => ({'type': 'ArrayExpression', elements})
 
 estemplate.object = value => ({
   'type': 'ObjectExpression',
-  'properties': value
+  'properties': extractExpr(value)
 })
 
 estemplate.objectProperty = (key, val) => ({
   'type': 'Property',
   'key': key,
   'computed': false,
-  'value': val,
+  'value': extractExpr(val),
   'kind': 'init',
   'method': false,
   'shorthand': false

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -329,7 +329,7 @@ const letExpressionParser = parser.bind(
   val => input => mayBe(
     parser.any(letExpressionParser, binaryExprParser, fnCallParser, expressionParser)(input),
       (body, rest) => {
-        val.expression.callee.body = body.type === 'ExpressionStatement' ? body.expression : body
+        val.callee.body = body.type === 'ExpressionStatement' ? body.expression : body
         return returnRest(val, input, rest.str)
       }
     )

--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -30,6 +30,7 @@ const statementType = expr => {
 }
 
 const exprType = (expr, localTypeObj = {}, id = null) => {
+  if (expr.type === 'ExpressionStatement') expr = expr.expression
   let type = expr.type
   switch (type) {
     case 'Literal':
@@ -122,7 +123,7 @@ const makeParamTypeArray = (localTypeObj) => {
 }
 
 const arrowFunctionExprType = (expr, localTypeObj, id) => {
-  let [params, body] = [expr.params, expr.body.type === 'ExpressionStatement' ? expr.body.expression : expr.body]
+  let [params, body] = [expr.params, expr.body]
   params.map(param => { localTypeObj[param.name] = 'needsInference' })
   let returnType = exprType(body, localTypeObj, id)
   return returnType === null ? null : {type: 'function', paramTypes: makeParamTypeArray(localTypeObj), returnType}

--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -122,7 +122,7 @@ const makeParamTypeArray = (localTypeObj) => {
 }
 
 const arrowFunctionExprType = (expr, localTypeObj, id) => {
-  let [params, body] = [expr.params, expr.body]
+  let [params, body] = [expr.params, expr.body.type === 'ExpressionStatement' ? expr.body.expression : expr.body]
   params.map(param => { localTypeObj[param.name] = 'needsInference' })
   let returnType = exprType(body, localTypeObj, id)
   return returnType === null ? null : {type: 'function', paramTypes: makeParamTypeArray(localTypeObj), returnType}


### PR DESCRIPTION
- The expression ast was being returned as is, because `ExpressionStatement` goes to the default case in `exprType` function of `typeInference.js`