### PR TITLE
Fix `memberExprParser`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -349,9 +349,9 @@ const memberExprParser = input => {
   if (parentObj === null) return null
   let [obj, rest] = parentObj
   let result = formMemberExpression(rest, obj)
-  if (result === null) return null
   let [memExpr, _rest] = result
-  return memExpr.type !== 'MemberExpression' ? returnRest(memExpr, input, _rest.str) : null
+  memExpr = memExpr.type === 'ExpressionStatement' ? memExpr.expression : memExpr
+  return memExpr.type === 'MemberExpression' ? returnRest(memExpr, input, _rest.str) : null
 }
 
 const subscriptParser = input => {


### PR DESCRIPTION
Only return `MemberExpression`