### PR TITLE
Fix `binaryExprParser`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -493,7 +493,7 @@ const binaryExprParser = src => {
     return descender(rest)
   }
   let [val, rest] = descender(src)
-  return val === null ? null : [val, rest]
+  return val !== null && val.type === 'BinaryExpression' ? [val, rest] : null
 }
 
 const keyParser = input => parser.any(identifierParser, stringParser, numberParser)(input)


### PR DESCRIPTION
- returns a value only if `val.type` is `BinaryExpression`