### PR TITLE
Fix type inference for recursive functions and conditional tests

### DIFF
--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -98,6 +98,7 @@ const matchArgTypesToAcceptedTypes = (args, acceptedTypes, localTypeObj, id) => 
 const checkForRecursion = (callee, id, localTypeObj, args) => {
   if (callee === id) { /* recursive call */
     args = args.map(e => exprType(e, localTypeObj, id))
+    if (globalTypesObj[id] !== undefined && globalTypesObj[id].type === 'function' && globalTypesObj[id].returnType !== 'needsInference') return {flag: false}
     globalTypesObj[id] = {type: 'function', paramTypes: args, returnType: 'needsInference'}
     return {flag: true, paramTypes: args}
   }

--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -67,8 +67,8 @@ const binaryExprType = (expr, localTypeObj, id) => {
 const conditionalExprType = (expr, localTypeObj, id) => {
   if (exprType(expr.test, localTypeObj, id) !== 'bool') return null
   let [consequentType, alternateType] = [exprType(expr.consequent, localTypeObj, id), exprType(expr.alternate, localTypeObj, id)]
-  if (consequentType === 'needsInference' && alternateType !== 'needsInference') consequentType = alternateType
-  if (consequentType !== 'needsInference' && alternateType === 'needsInference') alternateType = consequentType
+  if (consequentType === 'needsInference' && alternateType !== 'needsInference' && alternateType !== null) consequentType = alternateType
+  if (consequentType !== 'needsInference' && alternateType === 'needsInference' && consequentType !== null) alternateType = consequentType
   return consequentType === alternateType ? consequentType : null
 }
 

--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -33,14 +33,21 @@ const unaryExprType = expr => {
 const getType = (expr, expectedType, localTypeObj, id) => {
   if (expr !== undefined) {
     let type = exprType(expr, localTypeObj, id)
-    type = type === 'needsInference' ? expectedType : type
-    return type === expectedType || expectedType === 'bool' ? type : null
+    return type === expectedType || expectedType === 'bool' ? type : type === 'needsInference' ? type : null
   }
 }
 
 const checkTypes = (expr, expectedType, localTypeObj, id) => {
   let typeLeft = getType(expr.left, expectedType, localTypeObj, id)
   let typeRight = getType(expr.right, expectedType, localTypeObj, id)
+  if (typeLeft === 'needsInference' && typeRight !== 'needsInference') {
+    assignTypeToUninferredIdentifier(expr, typeRight, localTypeObj)
+    typeLeft = typeRight
+  }
+  if (typeLeft !== 'needsInference' && typeRight === 'needsInference') {
+    assignTypeToUninferredIdentifier(expr, typeLeft, localTypeObj)
+    typeRight = typeLeft
+  }
   return typeLeft === typeRight && (typeLeft === expectedType || expectedType === 'bool') ? expectedType : null
 }
 


### PR DESCRIPTION
- Assign only if `operator` is not `bool` and the other `operand` has a type
- Check `needsInference` in `consequent` and `alternate`
- Check if function has already defined `returnType` in `globalTypeObj`