### PR TITLE
Fix type inference for parameters in pattern matched functions

### DIFF
--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -1,11 +1,11 @@
 const errorTemplate = require('./estemplate').error
 const globalTypesObj = {}
 
-const isFunction = (id, typeObj) => typeObj[id] !== undefined && typeObj[id].type === 'function'
+const isFunction = (id, typeObj) => typeObj[id] !== undefined && typeObj[id] !== null && typeObj[id].type === 'function'
 
 const getParamReturnTypes = (id, typeObj) => [typeObj[id.name].paramTypes, typeObj[id.name].returnType]
 
-const isArray = (id, typeObj) => typeObj[id] !== undefined && typeObj[id].type === 'array'
+const isArray = (id, typeObj) => typeObj[id] !== undefined && typeObj[id] !== null && typeObj[id].type === 'array'
 
 const isEmpty = obj => obj.toString() === ''
 
@@ -117,17 +117,30 @@ const callExprType = (expr, localTypeObj = {}, id) => {
     return exprType(body, localTypeObj, id)
   }
   let isRecursive = checkForRecursion(expr.callee.name, id, localTypeObj, args)
-  let [acceptedTypes, returnType] = exprType(expr.callee, localTypeObj, id)
+  let result = exprType(expr.callee, localTypeObj, id)
+  if (result === null) return null
+  let [acceptedTypes, returnType] = result
   if (isRecursive.flag) acceptedTypes = isRecursive.paramTypes
   return matchArgTypesToAcceptedTypes(args, acceptedTypes, localTypeObj, id) ? returnType : null
 }
 
-const reduceTypes = (typesArr, localTypeObj, id) =>
-  (typesArr.map(e => exprType(e, localTypeObj, id))
-           .reduce((type1, type2) => {
-             if (type1 === 'needsInference' && type2 !== 'needsInference') type1 = type2
-             return type1 === type2 ? type1 : false
-           }))
+const reduceTypes = (typesArr, localTypeObj, id) => {
+  let reducedType = typesArr.map(e => {
+    if (e.type !== undefined && e.type === 'Identifier') return {id: e.name, type: exprType(e, localTypeObj, id)}
+    return {id: null, type: exprType(e, localTypeObj, id)}
+  }).reduce((exp1, exp2) => {
+    if (exp1.type === 'needsInference' && exp2.type !== 'needsInference' && exp2.type !== null) {
+      localTypeObj[exp1.id] = exp2.type
+      exp1.type = exp2.type
+    }
+    if (exp2.type === 'needsInference' && exp1.type !== 'needsInference') {
+      exp2.type = exp1.type
+      localTypeObj[exp2.id] = exp1.type
+    }
+    return exp1.type === exp2.type ? exp1 : false
+  })
+  return reducedType !== false ? reducedType.type : false
+}
 
 const switchStatementType = (body, localTypeObj, id) => {
   let cases = body.cases
@@ -137,12 +150,13 @@ const switchStatementType = (body, localTypeObj, id) => {
     initialPattern.test].map(exp => exprType(exp, localTypeObj, id))
   let paramId = body.discriminant.name
   localTypeObj[paramId] = acceptedType
-  globalTypesObj[id] = {type: 'function', paramTypes: makeParamTypeArray(localTypeObj, id), returnType}
   let [caseArgArray, caseTestArray] = [
     cases.map(c => c.consequent[0].argument),
     cases.map(c => c.test === null ? {type: 'Identifier', name: paramId, sType: acceptedType} : c.test)]
-  if (reduceTypes(caseArgArray, localTypeObj, id) === false || reduceTypes(caseTestArray, localTypeObj, id) === false) return null
-  return returnType
+  let checkArgsType = reduceTypes(caseArgArray, localTypeObj, id)
+  let checkTestType = reduceTypes(caseTestArray, localTypeObj, id)
+  globalTypesObj[id] = {type: 'function', paramTypes: makeParamTypeArray(localTypeObj, id), returnType}
+  return checkArgsType === false || checkTestType === false ? null : returnType
 }
 
 const blockStatementType = (stmnt, localTypeObj, id) => {


### PR DESCRIPTION
- Assign types to params inferred from `args` and `tests`
- Check if `function` and `array` types are not `null`