### PR TITLE
Add `true` and `false` to languageConstructs

### DIFF
--- a/lib/languageConstructs.js
+++ b/lib/languageConstructs.js
@@ -9,7 +9,9 @@ const languageConstructs = {
   'push': true,
   'pop': true,
   'shift': true,
-  'unshift': true
+  'unshift': true,
+  'true': true,
+  'false': true
 }
 
 module.exports = languageConstructs


### PR DESCRIPTION
To prevent them from being parsed as `identifiers`