### PR TITLE
Add command line flag to toggle `typeInference`

### DIFF
--- a/lib/astupdate.js
+++ b/lib/astupdate.js
@@ -1,4 +1,3 @@
-const inferTypes = require('./typeInference.js')
 const updateComment = require('./updateComment.js')
 
 let patterns = []
@@ -93,7 +92,7 @@ const updateAst = ast => {
     if (subtree !== null) newbody.push(subtree)
   })
   newbody = updateComment(newbody, ast)
-  ast.body = inferTypes(newbody)
+  ast.body = newbody
   return ast
 }
 

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -3,12 +3,15 @@ const escodegen = require('escodegen')
 const fs = require('fs')
 const parser = require('./parser')
 const childProcess = require('child_process')
-
+const inferTypes = require('./typeInference')
 const argv = argParser(process.argv.slice(2))
 const infile = argv._[0]
+const typeInferenceDisabled = argv.t !== undefined
+
 const outfile = infile.replace(/\.cl$/, '.js')
 const src = fs.readFileSync(infile, 'utf8').toString()
 const tree = parser({'str': src, 'line': 1, 'column': 0, 'indent': 0})
+tree.body = typeInferenceDisabled ? tree.body : inferTypes(tree.body)
 const out = escodegen.generate(tree, {comment: true})
 fs.writeFileSync(outfile, out, 'utf8')
 childProcess.execSync('node ' + outfile, {stdio: 'inherit'})


### PR DESCRIPTION
[in lib/astupdate.js]
- remove the call to `infeTypes`

[in lib/clean.js]
- add check for `typeInferenceDisabled` flag
- add a command line flag `-t` for type inference