### PR TITLE
Fix issue with consecutive standalaone `doBlocks`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -431,7 +431,7 @@ const doBlockParser = input => {
   let result = parser.all(doParser, getIOBody)(input)
   if (result === null) return null
   let [[, doBlock], rest] = result
-  return returnRest(doBlock, input, rest.str)
+  return returnRest(estemplate.expression(doBlock), input, rest.str)
 }
 
 const letExpressionParser = parser.bind(


### PR DESCRIPTION
- wrap standalone `doBlocks` in `ExpressionStatement`