### PR TITLE
Change the way `import` is handled

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -1,6 +1,5 @@
 const parser = require('./parserObject')
 const estemplate = require('./estemplate')
-const libPath = require('./import/libPath')
 
 /* Utility Functions */
 const {
@@ -204,15 +203,12 @@ const importKeywordParser = input => parser.regex(/^(import)((.|\n)*)$/)(input)
 
 const libNameParser = input => mayBe(
   parser.regex(/^(node-core|browser-core)((.|\n)*)$/)(input),
-  (val, rest) => {
-    val = libPath + val
-    return returnRest(estemplate.stringLiteral(val), input, rest.str)
-  }
+  (val, rest) => returnRest(val, input, rest.str)
 )
 
 const importParser = input => mayBe(
   parser.all(importKeywordParser, spaceParser, libNameParser)(input),
-  (val, rest) => returnRest(estemplate.import(val[2]), input, rest.str)
+  (val, rest) => returnRest(val[2], input, rest.str)
 )
 
 /* Module exports all basic parsers */

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const escodegen = require('escodegen')
+const importParser = require('./basicParsers').importParser
 const parser = require('./parser')
 const childProcess = require('child_process')
 const inferTypes = require('./typeInference')
@@ -27,8 +28,20 @@ module.exports = argsObj => {
   if (!infile) showAndExit(help)
   const outfile = argsObj.o || infile.replace(/\.cl$/, '.js')
   const commandLineArgs = argsObj._.slice(1)
-  const src = fs.readFileSync(infile, 'utf8').toString()
-  const tree = parser({'str': src, 'line': 1, 'column': 0, 'indent': 0})
+  let src = fs.readFileSync(infile, 'utf8').toString()
+  let input = {'str': src, 'line': 1, 'column': 0, 'indent': 0}
+  const importCheck = importParser(input)
+  let importCore = ''
+  if (importCheck !== null) {
+    let [libName, rest] = importCheck
+    let libFilePath = path.join(__dirname, '/import/' + libName + '.js')
+    input = rest
+    let coreIOPath = path.join(__dirname, '/import/core.js')
+    let coreIO = fs.readFileSync(coreIOPath, 'utf8').toString()
+    let libFile = fs.readFileSync(libFilePath, 'utf8').toString()
+    importCore = coreIO + '\n' + libFile + '\n'
+  }
+  const tree = parser(input)
   if (tree instanceof SyntaxError) {
     tree.message += ` in ${infile}`
     showAndExit(tree)
@@ -36,7 +49,7 @@ module.exports = argsObj => {
   if (argsObj.ast) console.log(JSON.stringify(tree, null, 2))
   tree.body = argsObj.t ? tree.body : inferTypes(tree.body)
   const out = escodegen.generate(tree, {comment: true})
-  fs.writeFileSync(outfile, out, 'utf8')
+  fs.writeFileSync(outfile, importCore + out, 'utf8')
   if (!argsObj.o) {
     const mayBeCliArgs = commandLineArgs.length > 0 ? ' ' + commandLineArgs.join(' ') : ''
     childProcess.execSync('node ' + outfile + mayBeCliArgs, {stdio: 'inherit'})

--- a/lib/import/core.js
+++ b/lib/import/core.js
@@ -1,138 +1,136 @@
-class IO {
+class IOCore {
   constructor (ioFunc) {
-    this.then = cb => ioFunc((...args) => { cb(...args) })
-  }
+    this.then = cb => ioFunc((...args) => { cb(...args) });
+  };
 
   reject (pred) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let result = pred(...args)
+        let result = pred(...args);
         if (result !== null) {
           if (Array.isArray(result)) {
-            cb(...result)
+            cb(...result);
           } else {
-            cb(result)
+            cb(result);
           }
-        }
-      })
-    }
-    return this
-  }
+        };
+      });
+    };
+    return this;
+  };
 
   mayBeFalse (mv, handler) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let result = mv(...args)
+        let result = mv(...args);
         if (result === false) {
-          handler(...args)
+          handler(...args);
         } else {
-          cb(...args)
+          cb(...args);
         }
-      })
-    }
-    return this
-  }
+      });
+    };
+    return this;
+  };
 
   mayBeNull (mv, handler) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
         let result = mv(...args)
         if (result === null) {
-          handler(...args)
+          handler(...args);
         } else {
-          cb(...args)
+          cb(...args);
         }
-      })
-    }
-    return this
-  }
+      });
+    };
+    return this;
+  };
 
   mayBeErr (mv, handler) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let result = mv(...args)
+        let result = mv(...args);
         if (result instanceof Error) {
-          handler(...args)
+          handler(...args);
         } else {
-          cb(...args)
+          cb(...args);
         }
-      })
-    }
-    return this
-  }
+      });
+    };
+    return this;
+  };
 
   mayBeTrue (mv, handler) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let result = mv(...args)
+        let result = mv(...args);
         if (result === true) {
-          handler(...args)
+          handler(...args);
         } else {
-          cb(...args)
+          cb(...args);
         }
-      })
-    }
-    return this
-  }
+      });
+    };
+    return this;
+  };
 
   mayBeUndefined (mv, handler) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let result = mv(...args)
+        let result = mv(...args);
         if (result === undefined) {
-          handler(...args)
+          handler(...args);
         } else {
-          cb(...args)
+          cb(...args);
         }
-      })
-    }
-    return this
-  }
+      });
+    };
+    return this;
+  };
 
   map (transform) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let result = transform(...args)
+        let result = transform(...args);
         if (Array.isArray(result)) {
-          cb(...result)
+          cb(...result);
         } else {
-          cb(result)
+          cb(result);
         }
-      })
-    }
-    return this
-  }
+      });
+    };
+    return this;
+  };
 
   bind (ioFunc) {
-    let saveThen = this.then
+    let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        let io = ioFunc(...args)
-        io.then((...ioargs) => cb(...args, ...ioargs))
-      })
-    }
-    return this
-  }
+        let io = ioFunc(...args);
+        io.then((...ioargs) => cb(...args, ...ioargs));
+      });
+    };
+    return this;
+  };
 
   static timer (s) {
-    var intervalId
-    var timer = new IO(cb => {
+    var intervalId;
+    var timer = new IOCore(cb => {
       intervalId = setInterval(cb, Math.floor(s * 1000))
-    })
-    timer.clear = () => clearInterval(intervalId)
-    return timer
-  }
+    });
+    timer.clear = () => clearInterval(intervalId);
+    return timer;
+  };
 
   static createIO (ioFunc) {
-    return new IO(ioFunc)
-  }
-}
-
-module.exports = IO
+    return new IOCore(ioFunc);
+  };
+};

--- a/lib/import/libPath.js
+++ b/lib/import/libPath.js
@@ -1,5 +1,0 @@
-const path = require('path')
-
-const libPath = path.join(__dirname, '/')
-
-module.exports = libPath

--- a/lib/import/node-core.js
+++ b/lib/import/node-core.js
@@ -1,38 +1,35 @@
-const IO = require('./core')
-const readline = require('readline')
-const fs = require('fs')
+const readline = require('readline');
+const fs = require('fs');
 
 const rlConfig = {
   input: process.stdin,
   output: process.stdout
-} /* Config for readline interface */
+}; /* Config for readline interface */
 
-class IONode extends IO {
+class IO extends IOCore {
   static getLine (str) {
-    const rl = readline.createInterface(rlConfig)
-    return new IO(cb => rl.question(str, cb))
+    const rl = readline.createInterface(rlConfig);
+    return new IOCore(cb => rl.question(str, cb))
       .map(data => {
-        rl.close()
-        return data
-      })
-  }
+        rl.close();
+        return data;
+      });
+  };
 
   static putLine (...data) {
-    return new IO(cb => process.nextTick(cb, data))
+    return new IOCore(cb => process.nextTick(cb, data))
       .map(data => {
-        console.log(...data)
+        console.log(...data);
         return data
-      })
-  }
+      });
+  };
 
   static readFile (filename) {
-    return new IO(cb => fs.readFile(filename, cb))
-      .map((_, data) => data.toString())
-  }
+    return new IOCore(cb => fs.readFile(filename, cb))
+      .map((_, data) => data.toString());
+  };
 
   static writeFile (filename, data) {
-    return new IO(cb => fs.writeFile(filename, data, cb))
-  }
-}
-
-module.exports = IONode
+    return new IOCore(cb => fs.writeFile(filename, data, cb));
+  };
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,7 @@ const {
   ifParser, thenParser, elseParser,
   slashParser, parenCheck,
   reverseBindParser, doParser, ioFuncNameParser, ioMethodNameParser, //, assignmentOperatorParser
-  returnKeywordParser, importParser
+  returnKeywordParser
 } = base
 
 const valueParser = input => parser.any(objectParser, binaryExprParser, unaryExprParser, letExpressionParser,
@@ -527,7 +527,7 @@ const ifExprParser = input => mayBe(
     }
 )
 
-const statementParser = input => parser.any(importParser, multiLineCommentParser, singleLineCommentParser, returnParser, doBlockParser, ioParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser, lambdaCallParser)(input)
+const statementParser = input => parser.any(multiLineCommentParser, singleLineCommentParser, returnParser, doBlockParser, ioParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser, lambdaCallParser)(input)
 
 const programParser = (input, ast = estemplate.ast()) => {
   let [, rest] = returnRest('', input, input.str)

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,176 @@
-const IO = require('<path_to_clean>/lib/import/node-core');
+class IOCore {
+  constructor (ioFunc) {
+    this.then = cb => ioFunc((...args) => { cb(...args) });
+  };
+
+  reject (pred) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = pred(...args);
+        if (result !== null) {
+          if (Array.isArray(result)) {
+            cb(...result);
+          } else {
+            cb(result);
+          }
+        };
+      });
+    };
+    return this;
+  };
+
+  mayBeFalse (mv, handler) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = mv(...args);
+        if (result === false) {
+          handler(...args);
+        } else {
+          cb(...args);
+        }
+      });
+    };
+    return this;
+  };
+
+  mayBeNull (mv, handler) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = mv(...args)
+        if (result === null) {
+          handler(...args);
+        } else {
+          cb(...args);
+        }
+      });
+    };
+    return this;
+  };
+
+  mayBeErr (mv, handler) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = mv(...args);
+        if (result instanceof Error) {
+          handler(...args);
+        } else {
+          cb(...args);
+        }
+      });
+    };
+    return this;
+  };
+
+  mayBeTrue (mv, handler) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = mv(...args);
+        if (result === true) {
+          handler(...args);
+        } else {
+          cb(...args);
+        }
+      });
+    };
+    return this;
+  };
+
+  mayBeUndefined (mv, handler) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = mv(...args);
+        if (result === undefined) {
+          handler(...args);
+        } else {
+          cb(...args);
+        }
+      });
+    };
+    return this;
+  };
+
+  map (transform) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let result = transform(...args);
+        if (Array.isArray(result)) {
+          cb(...result);
+        } else {
+          cb(result);
+        }
+      });
+    };
+    return this;
+  };
+
+  bind (ioFunc) {
+    let saveThen = this.then;
+    this.then = cb => {
+      saveThen((...args) => {
+        let io = ioFunc(...args);
+        io.then((...ioargs) => cb(...args, ...ioargs));
+      });
+    };
+    return this;
+  };
+
+  static timer (s) {
+    var intervalId;
+    var timer = new IOCore(cb => {
+      intervalId = setInterval(cb, Math.floor(s * 1000))
+    });
+    timer.clear = () => clearInterval(intervalId);
+    return timer;
+  };
+
+  static createIO (ioFunc) {
+    return new IOCore(ioFunc);
+  };
+};
+
+const readline = require('readline');
+const fs = require('fs');
+
+const rlConfig = {
+  input: process.stdin,
+  output: process.stdout
+}; /* Config for readline interface */
+
+class IO extends IOCore {
+  static getLine (str) {
+    const rl = readline.createInterface(rlConfig);
+    return new IOCore(cb => rl.question(str, cb))
+      .map(data => {
+        rl.close();
+        return data;
+      });
+  };
+
+  static putLine (...data) {
+    return new IOCore(cb => process.nextTick(cb, data))
+      .map(data => {
+        console.log(...data);
+        return data
+      });
+  };
+
+  static readFile (filename) {
+    return new IOCore(cb => fs.readFile(filename, cb))
+      .map((_, data) => data.toString());
+  };
+
+  static writeFile (filename, data) {
+    return new IOCore(cb => fs.writeFile(filename, data, cb));
+  };
+};
+
 const request = require('request');
 const fact = n => {
     switch (n) {


### PR DESCRIPTION
Fixes #122 

[in lib/basicParsers.js]
 - Remove unused file `import/libPath.js`
 - `importParser` now only returns the parsed library name

[in lib/cli.js]
 - Parse import statements at the beginning and prepend them to
generated js file

[in lib/import/core.js]
 - Rename `IO` to `IOCore` and remove `module.exports`

[deleted lib/import/libPath.js]

[in lib/import/node-core.js]
 - Rename `IONode` to `IO` and remove `module.exports`

[in lib/parser.js]
 - Remove `importParser` as imports are parsed in `cli.js`

[in test.js]
 - Update file to include core files