### PR TITLE
Change `valueParser` to `expressionParser` in `mayBeStmtParser`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -246,7 +246,7 @@ const handlerParser = input => {
   return returnRest(val, input, rest.str)
 }
 
-const mayBeStmtParser = input => parser.all(ioMethodNameParser, spaceParser, valueParser, spaceParser, handlerParser)(input)
+const mayBeStmtParser = input => parser.all(ioMethodNameParser, spaceParser, expressionParser, spaceParser, handlerParser)(input)
 
 const defineStmtParser = input => {
   let result = parser.all(identifierParser, spaceParser, parser.any(memberExprParser, identifierParser), spaceParser, stringParser, spaceParser, valueParser)(input)


### PR DESCRIPTION
Example:

`mayBeUndefined req.session.user (res.redirect '/login')`

`valueParser`consumes `req.session.user (res.redirect '/login')` as a whole and makes a function call out of `req.session.user` with `(res.redirect '/login')` as its argument