### PR TITLE
Rename create io

### DIFF
--- a/lib/ioMethods.js
+++ b/lib/ioMethods.js
@@ -3,7 +3,7 @@ const ioFuncs = {
   'getLine': true,
   'readFile': true,
   'writeFile': true,
-  'createIO': true
+  'IO': true
 }
 
 const ioMeths = {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -312,9 +312,10 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
 
     let [ioFunc, , args] = isIOCall ? [null, null, null] : mayBeIOFunc
 
-    if (ioFunc !== null && ioFunc.name === 'createIO' && args[0].type === 'CallExpression') {
+    if (ioFunc !== null && ioFunc.name === 'IO' && args[0].type === 'CallExpression') {
       let [func] = args
       let cb = estemplate.identifier('cb')
+      ioFunc.name = 'createIO'
       func.arguments = func.arguments.concat(cb)
       args = [estemplate.lambda([cb], func).expression]
     }

--- a/tests/test.cl
+++ b/tests/test.cl
@@ -13,7 +13,7 @@ computeFact = do
 getAscii = do
      data <- computeFact
      let link = 'http://artii.herokuapp.com/make?text=' ++ data
-     err res body <- createIO (request link)
+     err res body <- IO (request link)
      mayBeErr err (putLine err)
      putLine body
      return body


### PR DESCRIPTION
`createIO` is now `IO` in `clean` and whereas it remains the same(`createIO`) in `core`