### PR TITLE
Add support for `do` Blocks in function declarations

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -190,7 +190,7 @@ const bindIDParser = (input, idArray = []) => {
 }
 
 const bindStatementParser = input => parser.all(bindIDParser, reverseBindParser,
-                                                parser.any(parser.all(
+                                                parser.any(fnCallParser, parser.all(
                                                   ioFuncNameParser,
                                                   mayBeSpace,
                                                   argsParser),
@@ -308,9 +308,9 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
   if (mayBeBind !== null) {
     let [[bindID, , mayBeIOFunc], rest] = mayBeBind
     let nextParams = parentObj.nextParams === undefined ? bindID : parentObj.nextParams.concat(bindID)
+    let isFuncCall = mayBeIOFunc.type !== undefined && mayBeIOFunc.expression.type === 'CallExpression'
     let isIOCall = mayBeIOFunc.type !== undefined && mayBeIOFunc.type === 'Identifier'
-
-    let [ioFunc, , args] = isIOCall ? [null, null, null] : mayBeIOFunc
+    let [ioFunc, , args] = isIOCall || isFuncCall ? [null, null, null] : mayBeIOFunc
 
     if (ioFunc !== null && ioFunc.name === 'IO' && args[0].type === 'CallExpression') {
       let [func] = args
@@ -321,11 +321,13 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
     }
 
     if (isEmptyObj(parentObj)) {
-      let val = isIOCall ? mayBeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
-      val.nextParams = isIOCall ? nextParams : val.nextParams
+      let val = isIOCall || isFuncCall ? mayBeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
+      if (isFuncCall) val = val.expression
+      val.nextParams = isIOCall || isFuncCall ? nextParams : val.nextParams
       return getIOBody(rest, val, thenBody)
     }
-    let cbBody = isIOCall ? mayBeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
+    let cbBody = isIOCall || isFuncCall ? mayBeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
+    if (isFuncCall) cbBody = cbBody.expression
     cbBody.nextParams = isIOCall ? nextParams : cbBody.nextParams
     let cbParams = parentObj.nextParams
     let callBack = estemplate.lambda(cbParams, cbBody)
@@ -450,6 +452,15 @@ const doBlockParser = input => {
   return returnRest(estemplate.expression(doBlock), input, rest.str)
 }
 
+const doFuncParser = input => {
+  let result = parser.all(identifierParser, paramsParser, equalSignParser, doBlockParser)(input)
+  if (result === null) return null
+  let [[funcId,params, , funcBody], rest] = result
+  let val = estemplate.funcDeclaration(funcId, params, funcBody.expression)
+  val.sType = 'IO'
+  return returnRest(val, input, rest.str)
+}
+
 const letExpressionParser = parser.bind(
   parser.bind(
     parser.bind(
@@ -543,7 +554,7 @@ const ifExprParser = input => mayBe(
     }
 )
 
-const statementParser = input => parser.any(multiLineCommentParser, singleLineCommentParser, returnParser, doBlockParser, ioParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser, lambdaCallParser, spaceParser)(input)
+const statementParser = input => parser.any(multiLineCommentParser, singleLineCommentParser, returnParser, doBlockParser, ioParser, doFuncParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser, lambdaCallParser, spaceParser)(input)
 
 const programParser = (input, ast = estemplate.ast()) => {
   let [, rest] = returnRest('', input, input.str)


### PR DESCRIPTION
- Add `doFuncParser`
- Modify `getIOBody` to add support for do blocks
- Add `doFuncParser` to the `statementParser`
- Add `fnCallParser` to `bindStatementParser`