### PR TITLE
Refactor valueParser, expressionParser, parenthesesParser

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -31,7 +31,6 @@ const colonRegex = /^(:)((.|\n)*)$/
 const singleLineCommentRegex = /^((\/\/)(.*)(\n))((.|\n)*)$/
 const multiLineCommentRegex = /^((\/\*)((.|\n)*?)(\*\/))((.|\n)*)$/
 const nullRegex = /^(null)((.|\n)*)$/
-const assignmentOperatorRegex = /^(\+=|-=|\*=|\/=|\*\*=|>>>=|>>=|<<=|%=|&=|\^=|\|=|=)((.|\n)*)$/
 const deleteRegex = /^(delete)((.|\n)*)$/
 const regexRegex = /^(\/((.|\n)*)\/(\w*))((.|\n)*)$/
 
@@ -41,8 +40,6 @@ const regexRegex = /^(\/((.|\n)*)\/(\w*))((.|\n)*)$/
 const spaceParser = parser.regex(spaceRegex)
 
 const equalSignParser = parser.regex(/^(\s+=\s+)((.|\n)*)$/)
-
-const assignmentOperator = parser.regex(assignmentOperatorRegex)
 
 const thinArrowParser = parser.regex(/^(\s*->\s+)((.|\n)*)$/)
 
@@ -174,13 +171,6 @@ const binaryOperatorParser = input => mayBe(
     return returnRest(op, input, rest.str, {'name': 'column', 'value': (sp1 + op + sp2).length})
   })
 
-const assignmentOperatorParser = input => {
-  let result = parser.all(spaceParser, assignmentOperator, spaceParser)(input)
-  if (result === null) return null
-  let [[sp1, val, sp2], rest] = result
-  return returnRest(val, input, rest.str, {'name': 'column', 'value': (sp1 + val + sp2).length})
-}
-
 const unaryOperatorParser = input => mayBe(
     unaryOperatorRegex.exec(input.str),
     (m, operator, rest) => returnRest(operator, input, rest, {'name': 'column', 'value': operator.length})
@@ -266,7 +256,6 @@ module.exports = {
   equalSignParser,
   slashParser,
   parenCheck,
-  assignmentOperatorParser,
   returnKeywordParser,
   importParser,
   deleteKeywordParser

--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -1,7 +1,7 @@
 const types = require('./operatorPrecedence')
 let estemplate = {}
 
-const extractExpr = token => token !== undefined && token.type === 'ExpressionStatement' ? token.expression : token
+const extractExpr = token => token !== undefined && token !== null && token.type === 'ExpressionStatement' ? token.expression : token
 
 estemplate.import = lib => ({
   'type': 'VariableDeclaration',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,7 @@ const {
   letParser, inParser,
   ifParser, thenParser, elseParser,
   slashParser, parenCheck,
-  reverseBindParser, doParser, ioFuncNameParser, ioMethodNameParser, //, assignmentOperatorParser
+  reverseBindParser, doParser, ioFuncNameParser, ioMethodNameParser,
   returnKeywordParser, deleteKeywordParser
 } = base
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -32,23 +32,21 @@ const {
   returnKeywordParser, deleteKeywordParser
 } = base
 
-const valueParser = input => parser.any(objectParser, regexParser, binaryExprParser, unaryExprParser, letExpressionParser,
-                                        ifExprParser, fnCallParser, arrayParser, memberExprParser,
-                                        expressionParser)(input)
+const valueParser = input => parser.any(binaryExprParser, fnCallParser, expressionParser)(input)
 
 const parenthesesParser = input => {
-  let result = parser.all(
-    openParensParser, mayBeNewLineAndIndent,
-    parser.any(lambdaCallParser, lambdaParser, letExpressionParser, ifExprParser, regexParser, unaryExprParser, binaryExprParser, fnCallParser, expressionParser),
-    mayBeNewLineAndIndent, closeParensParser
-  )(input)
+  let result = parser.all(openParensParser, mayBeNewLineAndIndent,
+                          valueParser, mayBeNewLineAndIndent, closeParensParser)(input)
 
   if (result === null) return null
   let [[, , val], rest] = result
   return returnRest(val, input, rest.str)
 }
 
-const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaParser, lambdaCallParser, fnCallParser, memberExprParser, arrayParser, objectParser, parenthesesParser, booleanParser, identifierParser, numberParser, nullParser, stringParser)(input)
+const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaParser, lambdaCallParser,
+                                             letExpressionParser, ifExprParser, memberExprParser, arrayParser,
+                                             objectParser, booleanParser, identifierParser, numberParser,
+                                             nullParser, stringParser)(input)
 
 const unaryExprParser = parser.bind(
   parser.bind(

--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -365,7 +365,7 @@ const blockStatementType = (stmnt, localTypeObj, id) => {
 }
 
 const exprType = (expr, localTypeObj = {}, id = null) => {
-  if (expr.sType !== undefined && expr.sType === 'IO') return 'IO'
+  if (expr !== null && expr.sType !== undefined && expr.sType === 'IO') return 'IO'
   if (expr === null) return 'needsInference'
   if (expr.type === 'ExpressionStatement') expr = expr.expression
   let type = expr.type


### PR DESCRIPTION
- Remove unused parser `assignmentOperatorParser`
- Remove redundant use of parsers in `valueParser`, `parenthesesParser`, and `expressionParser`
- Check if `expr` is `null` in `extractExpr` when value in `array` is `null`