### PR TITLE
Fix issues with `bind`

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -312,7 +312,7 @@ estemplate.ioCall = (ioFunc, args, nextParams = []) => ({
   nextParams
 })
 
-estemplate.ioBind = (parentIO, ioCall, nextParams = []) => ({
+estemplate.ioBind = (parentIO, ioCall, nextParams = []) => estemplate.ioMap({
   'type': 'CallExpression',
   'callee': {
     'type': 'MemberExpression',
@@ -325,7 +325,7 @@ estemplate.ioBind = (parentIO, ioCall, nextParams = []) => ({
   },
   'arguments': [ioCall].map(extractExpr),
   nextParams
-})
+}, estemplate.lambda(nextParams, estemplate.array(nextParams)), nextParams)
 
 estemplate.ioMap = (parentIO, pureFunc, nextParams = []) => ({
   'type': 'CallExpression',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -327,7 +327,7 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
         parentObj = getCbBody(cbBody, parentObj)
         let returnVals = parentObj.returnVals
         let callBack = estemplate.lambda(cbParams, estemplate.array(returnVals)).expression
-        let val = estemplate.ioMap(parentObj, callBack, cbParams)
+        let val = estemplate.lambda([], estemplate.ioMap(parentObj, callBack, cbParams)).expression
         val.sType = 'IO'
         return returnRest(val, input, rest.str)
       } else {
@@ -355,6 +355,7 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
     let nextParams = parentObj.nextParams === undefined ? bindID : parentObj.nextParams.concat(bindID)
     let isFuncCall = mayBeIOFunc.type !== undefined && mayBeIOFunc.expression !== undefined && mayBeIOFunc.expression.type === 'CallExpression'
     let isIOCall = mayBeIOFunc.type !== undefined && mayBeIOFunc.type === 'Identifier'
+    if (isIOCall) mayBeIOFunc = estemplate.fnCall(mayBeIOFunc, [])
     let [ioFunc, , args] = isIOCall || isFuncCall ? [null, null, null] : mayBeIOFunc
 
     if (ioFunc !== null && ioFunc.name === 'IO' && args[0].type === 'CallExpression') {
@@ -483,7 +484,7 @@ const ioParser = input => {
     [ioBody, rest] = result
     ioBody.expression = false
   } else {
-    ioBody = estemplate.defaultIOThen(mayBeDo)
+    ioBody = estemplate.defaultIOThen(estemplate.fnCall(mayBeDo, []))
   }
 
   ioBody.sType = 'IO'

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -366,7 +366,9 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
     }
 
     if (isEmptyObj(parentObj)) {
-      let val = isIOCall || isFuncCall ? mayBeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
+      let val = isIOCall || isFuncCall ? mayBeIOFunc : estemplate.ioMap(estemplate.ioCall(ioFunc, args, nextParams),
+                                         estemplate.lambda(nextParams, estemplate.array(nextParams)),
+                                         nextParams)
       if (isFuncCall) val = val.expression
       val.nextParams = isIOCall || isFuncCall ? nextParams : val.nextParams
       return getIOBody(rest, val, thenBody)

--- a/tests/test.js
+++ b/tests/test.js
@@ -9,15 +9,23 @@ const fact = n => {
         return n * fact(n - 1);
     }
 };
-const computeFact = IO.getLine('enter value for factorial: ').map(num => [
-    fact(parseInt(num)),
-    num
-]).bind((val, num) =>
-    (IO.putLine(val))).map((val, num) => [String(val)]);
-const getAscii = computeFact.map(data => [
-    'http://artii.herokuapp.com/make?text=' + data,
-    data
-]).bind((link, data) => IO.createIO(cb => request(link, cb))).maybeErr((link, data, err, res, body) => err, (link, data, err, res, body) => IO.putLine(err).then(() => null)).bind((link, data, err, res, body) =>
-    (IO.putLine(body))).map((link, data, err, res, body) => [body]);
+const computeFact = () =>
+    (IO.getLine('enter value for factorial: ').map(num => [num]).map(num => [
+        fact(parseInt(num)),
+        num
+    ]).bind((val, num) =>
+        (IO.putLine(val))).map((val, num) => [String(val)]));
+const getAscii = () =>
+    (computeFact().map(data => [
+        'http://artii.herokuapp.com/make?text=' + data,
+        data
+    ]).bind((link, data) => IO.createIO(cb => request(link, cb))).map((link, data, err, res, body) => [
+        link,
+        data,
+        err,
+        res,
+        body
+    ]).maybeErr((link, data, err, res, body) => err, (link, data, err, res, body) => IO.putLine(err).then(() => null)).bind((link, data, err, res, body) =>
+        (IO.putLine(body))).map((link, data, err, res, body) => [body]));
 const tempIO = getAscii;
-const main = tempIO.then(() => null);
+const main = tempIO().then(() => null);


### PR DESCRIPTION
- Propagate only values specified by user
- Wrap `do` blocks with `return` inside a `lambda`