### PR TITLE
Object properties can now be reserved keywords

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -71,10 +71,15 @@ const numberParser = input => mayBe(
   (a, num, rest) => returnRest(estemplate.literal(num, num), input, rest, {'name': 'column', 'value': num.length})
 )
 
-const identifierParser = input => mayBe(
+const nonReservedIdParser = input => mayBe(
   idRegex.exec(input.str),
   (a, name, rest) => (isLanguageConstruct(name) || isIOFunc(name) || isIOMethod(name)) ? null
     : returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}))
+
+const identifierParser = input => mayBe(
+  idRegex.exec(input.str),
+  (a, name, rest) => returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
+)
 
 const ioFuncNameParser = input => mayBe(
   idRegex.exec(input.str),
@@ -231,6 +236,7 @@ module.exports = {
   mayBeSpace,
   mayBeNewLineAndIndent,
   numberParser,
+  nonReservedIdParser,
   identifierParser,
   ioFuncNameParser,
   ioMethodNameParser,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,7 +18,7 @@ const {
 /* Base Parsers */
 const {
   returnParser, spaceParser, mayBeSpace, mayBeNewLineAndIndent,
-  numberParser, identifierParser, nullParser, stringParser, booleanParser,
+  numberParser, nonReservedIdParser, identifierParser, nullParser, stringParser, booleanParser,
   regexParser, openParensParser, closeParensParser,
   openCurlyBraceParser, closeCurlyBraceParser,
   openSquareBracketParser, closeSquareBracketParser,
@@ -45,7 +45,7 @@ const parenthesesParser = input => {
 
 const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaParser, lambdaCallParser,
                                              letExpressionParser, ifExprParser, memberExprParser, arrayParser,
-                                             objectParser, booleanParser, identifierParser, numberParser,
+                                             objectParser, booleanParser, nonReservedIdParser, numberParser,
                                              nullParser, stringParser)(input)
 
 const unaryExprParser = parser.bind(
@@ -106,7 +106,7 @@ const handleOrder = (opStack, operandStack, current, input, rest) => {
 
 const declParser = parser.bind(
   parser.bind(
-    identifierParser,
+    nonReservedIdParser,
     val => input => mayBe(
         equalSignParser(input),
         (v, rest) => [val, rest]
@@ -120,7 +120,7 @@ const declParser = parser.bind(
       )
 )
 
-const paramParser = input => parser.all(spaceParser, parser.any(arrayParser, objectParser, identifierParser, numberParser, nullParser, stringParser))(input)
+const paramParser = input => parser.all(spaceParser, parser.any(arrayParser, objectParser, nonReservedIdParser, numberParser, nullParser, stringParser))(input)
 
 const paramsParser = (str, paramArray = []) => {
   let param = paramParser(str)
@@ -138,7 +138,7 @@ const getLengthOf = params => params.map(p => p.name !== undefined
 const fnDeclParser = parser.bind(
   parser.bind(
     parser.bind(
-      identifierParser,
+      nonReservedIdParser,
       val => input => mayBe(
         paramsParser(input),
         (params, rest) => {
@@ -161,7 +161,7 @@ const fnDeclParser = parser.bind(
     )
 )
 
-const lambdaParamParser = input => parser.all(identifierParser, spaceParser)(input)
+const lambdaParamParser = input => parser.all(nonReservedIdParser, spaceParser)(input)
 
 const lambdaParamsParser = (str, lambdaparamArray = []) => {
   let arg = lambdaParamParser(str)
@@ -215,7 +215,7 @@ const lambdaCallParser = input => {
   return returnRest(val, input, rest.str)
 }
 
-const letParamParser = input => parser.all(identifierParser, equalSignParser, valueParser, mayBeSpace)(input)
+const letParamParser = input => parser.all(nonReservedIdParser, equalSignParser, valueParser, mayBeSpace)(input)
 
 const letParamsParser = (str, letIdArray = [], letLiteralArray = []) => {
   let param = letParamParser(str)
@@ -227,7 +227,7 @@ const letParamsParser = (str, letIdArray = [], letLiteralArray = []) => {
 }
 
 const bindIDParser = (input, idArray = []) => {
-  let result = parser.all(identifierParser, spaceParser)(input)
+  let result = parser.all(nonReservedIdParser, spaceParser)(input)
   if (result === null && idArray.length === 0) return null
   if (result === null) return returnRest(idArray, input, input.str)
   let [[id], rest] = result
@@ -239,7 +239,7 @@ const bindStatementParser = input => parser.all(bindIDParser, reverseBindParser,
                                                   ioFuncNameParser,
                                                   mayBeSpace,
                                                   argsParser),
-                                                           identifierParser))(input)
+                                                           nonReservedIdParser))(input)
 
 const letStmtParser = input => {
   let result = parser.all(letParser, letParamsParser)(input)
@@ -294,7 +294,7 @@ const handlerParser = input => {
 const mayBeStmtParser = input => parser.all(ioMethodNameParser, spaceParser, expressionParser, spaceParser, handlerParser)(input)
 
 const defineStmtParser = input => {
-  let result = parser.all(identifierParser, spaceParser, parser.any(memberExprParser, identifierParser), spaceParser, stringParser, spaceParser, valueParser)(input)
+  let result = parser.all(nonReservedIdParser, spaceParser, parser.any(memberExprParser, nonReservedIdParser), spaceParser, stringParser, spaceParser, valueParser)(input)
   if (result === null) return null
   let [val, rest] = result
   let [id] = val
@@ -302,7 +302,7 @@ const defineStmtParser = input => {
   return returnRest(val, input, rest.str)
 }
 
-const deleteStmtParser = input => parser.all(deleteKeywordParser, spaceParser, parser.any(memberExprParser, identifierParser))(input)
+const deleteStmtParser = input => parser.all(deleteKeywordParser, spaceParser, parser.any(memberExprParser, nonReservedIdParser))(input)
 
 const getIOBody = (input, parentObj = {}, thenBody = []) => {
   let finalStmt = returnParser(input)
@@ -443,7 +443,7 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
     return getIOBody(rest, parentObj, thenBody.concat(fnCall))
   }
 
-  let mayBeIOCall = identifierParser(input)
+  let mayBeIOCall = nonReservedIdParser(input)
   if (mayBeIOCall !== null) {
     let [ioID, rest] = mayBeIOCall
     if (isEmptyObj(parentObj)) {
@@ -458,7 +458,7 @@ const getIOBody = (input, parentObj = {}, thenBody = []) => {
 
 const noArgsCallParser = input => {
   let result = parser.all(
-    parser.any(memberExprParser, parenthesesParser, identifierParser),
+    parser.any(memberExprParser, parenthesesParser, nonReservedIdParser),
     spaceParser, openParensParser, closeParensParser
   )(input)
   if (result === null) return null
@@ -467,7 +467,7 @@ const noArgsCallParser = input => {
 }
 
 const ioParser = input => {
-  let initIO = parser.all(identifierParser, equalSignParser, parser.any(doParser, noArgsCallParser, ioStmtParser, identifierParser))(input)
+  let initIO = parser.all(nonReservedIdParser, equalSignParser, parser.any(doParser, noArgsCallParser, ioStmtParser, nonReservedIdParser))(input)
   if (initIO === null) return null
   let [[doID, , mayBeDo], rest] = initIO
   if (mayBeDo.type !== undefined && mayBeDo.type === 'Identifier' && doID.name !== 'main') return null
@@ -501,7 +501,7 @@ const doBlockParser = input => {
 }
 
 const doFuncParser = input => {
-  let result = parser.all(identifierParser, paramsParser, equalSignParser, doBlockParser)(input)
+  let result = parser.all(nonReservedIdParser, paramsParser, equalSignParser, doBlockParser)(input)
   if (result === null) return null
   let [[funcId,params, , funcBody], rest] = result
   let val = estemplate.funcDeclaration(funcId, params, funcBody.expression)
@@ -543,7 +543,7 @@ const formMemberExpression = (input, obj) => {
 }
 
 const memberExprParser = input => {
-  let parentObj = parser.any(arrayParser, identifierParser, parenthesesParser)(input)
+  let parentObj = parser.any(arrayParser, nonReservedIdParser, parenthesesParser)(input)
   if (parentObj === null) return null
   let [obj, rest] = parentObj
   let result = formMemberExpression(rest, obj)
@@ -555,7 +555,7 @@ const memberExprParser = input => {
 const subscriptParser = input => {
   let result = parser.all(
   openSquareBracketParser,
-  parser.any(memberExprParser, identifierParser, numberParser, stringParser),
+  parser.any(memberExprParser, nonReservedIdParser, numberParser, stringParser),
     closeSquareBracketParser)(input)
   if (result !== null) {
     let [[, prop], rest] = result
@@ -579,7 +579,7 @@ const argsParser = (input, argArray = []) => {
 }
 
 const fnCallParser = parser.bind(
-  parser.all(parser.any(memberExprParser, identifierParser), spaceParser),
+  parser.all(parser.any(memberExprParser, nonReservedIdParser), spaceParser),
   val => input => mayBe(
     parser.any(emptyArgsParser, argsParser)(input),
       (args, rest) => {


### PR DESCRIPTION
[in lib/basicParsers.js]
 - Rename `identifierParser` to `nonReservedIdParser` to parse
 `identifiers` which are not reserved
 - Add `identifierParser` to parse all `identifiers`

[in lib/parser.js]
 - Replace all instances of `identifierParser` with
 `nonReservedIdParser` except in `memberExprParser` because objects
 can have reserved keywords as keys