### PR TITLE
Refactor and reformat code

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -3,229 +3,237 @@ const estemplate = require('./estemplate')
 
 /* Utility Functions */
 const {
-  mayBe,
+  maybe,
   isLanguageConstruct,
   isIOFunc,
   isIOMethod,
+  isNull,
+  notNull,
   unescape,
   returnRest
 } = require('./utilityFunctions')
 
 /*  Predefined regexes */
-const spaceRegex = /^([ \t]+)((.|\n)*)$/
-const returnRegex = /^(\n)((.|\n)*)$/
-const idRegex = /^([_a-zA-Z]+[a-zA-Z0-9_]*)((.|\n)*)$/
-const numRegex = /^((?:\d+(?:\.\d*)?|\.\d+)(?:[e][+-]?\d+)?)((.|\n)*)$/
-const boolRegex = /^(true|false)((.|\n)*)$/i
-const stringRegex = /^('[^\\']*(?:\\.[^\\']*)*')((.|\n)*)$/
-const binaryOperatorRegex = /^(\+\+|\+|-|%|\/|\*|<<|<=|<|>y>>|>>|>=|>|&&|&|\|\||\||\^|==|!=)((.|\n)*)$/
-const unaryOperatorRegex = /^(:type|-|!)((.|\n)*)$/
-const openCurlyRegex = /^({)((.|\n)*)$/
-const closeCurlyRegex = /^(})((.|\n)*)$/
-const openSquareBracketRegex = /^(\[)((.|\n)*)$/
-const closeSquareBracketRegex = /^(])((.|\n)*)$/
-const openParensRegex = /^(\()((.|\n)*)$/
-const closeParensRegex = /^(\))((.|\n)*)$/
-const commaRegex = /^(,)((.|\n)*)$/
-const colonRegex = /^(:)((.|\n)*)$/
-const singleLineCommentRegex = /^((\/\/)(.*)(\n))((.|\n)*)$/
-const multiLineCommentRegex = /^((\/\*)((.|\n)*?)(\*\/))((.|\n)*)$/
-const nullRegex = /^(null)((.|\n)*)$/
-const deleteRegex = /^(delete)((.|\n)*)$/
-const regexRegex = /^(\/((.|\n)*)\/(\w*))((.|\n)*)$/
+const spaceRegex = () => /^([ \t]+)((.|\n)*)$/
+const returnRegex = () => /^(\n)((.|\n)*)$/
+const idRegex = () => /^([_a-zA-Z]+[a-zA-Z0-9_]*)((.|\n)*)$/
+const numRegex = () => /^((?:\d+(?:\.\d*)?|\.\d+)(?:[e][+-]?\d+)?)((.|\n)*)$/
+const boolRegex = () => /^(true|false)((.|\n)*)$/i
+const stringRegex = () => /^('[^\\']*(?:\\.[^\\']*)*')((.|\n)*)$/
+const binaryOperatorRegex = () => /^(\+\+|\+|-|%|\/|\*|<<|<=|<|>y>>|>>|>=|>|&&|&|\|\||\||\^|==|!=)((.|\n)*)$/
+const unaryOperatorRegex = () => /^(:type|-|!)((.|\n)*)$/
+const openCurlyRegex = () => /^({)((.|\n)*)$/
+const closeCurlyRegex = () => /^(})((.|\n)*)$/
+const openSquareBracketRegex = () => /^(\[)((.|\n)*)$/
+const closeSquareBracketRegex = () => /^(])((.|\n)*)$/
+const openParensRegex = () => /^(\()((.|\n)*)$/
+const closeParensRegex = () => /^(\))((.|\n)*)$/
+const commaRegex = () => /^(,)((.|\n)*)$/
+const colonRegex = () => /^(:)((.|\n)*)$/
+const singleLineCommentRegex = () => /^((\/\/)(.*)(\n))((.|\n)*)$/
+const multiLineCommentRegex = () => /^((\/\*)((.|\n)*?)(\*\/))((.|\n)*)$/
+const nullRegex = () => /^(null)((.|\n)*)$/
+const deleteRegex = () => /^(delete)((.|\n)*)$/
+const regexRegex = () => /^(\/((.|\n)*)\/(\w*))((.|\n)*)$/
 
 /*
   All required parsers are created below
 */
-const spaceParser = parser.regex(spaceRegex)
+const spaceParser = input => parser.regex(spaceRegex())(input)
 
-const equalSignParser = parser.regex(/^(\s+=\s+)((.|\n)*)$/)
+const equalSignParser = input => parser.regex(/^(\s+=\s+)((.|\n)*)$/)(input)
 
-const thinArrowParser = parser.regex(/^(\s*->\s+)((.|\n)*)$/)
+const thinArrowParser = input => parser.regex(/^(\s*->\s+)((.|\n)*)$/)(input)
 
-const reverseBindParser = parser.regex(/^(\s*<-\s+)((.|\n)*)$/)
+const reverseBindParser = input => parser.regex(/^(\s*<-\s+)((.|\n)*)$/)(input)
 
-const slashParser = parser.regex(/^(\s*\\)((.|\n)*)$/)
+const slashParser = input => parser.regex(/^(\s*\\)((.|\n)*)$/)(input)
 
-const letParser = parser.regex(/^(\s*let\s+)((.|\n)*)$/)
+const letParser = input => parser.regex(/^(\s*let\s+)((.|\n)*)$/)(input)
 
-const inParser = parser.regex(/^(\s*in\s+)((.|\n)*)$/)
+const inParser = input => parser.regex(/^(\s*in\s+)((.|\n)*)$/)(input)
 
-const dotParser = parser.regex(/^(\.)((.|\n)*)$/)
+const dotParser = input => parser.regex(/^(\.)((.|\n)*)$/)(input)
 
-const ifParser = parser.regex(/^(if\s+)((.|\n)*)$/)
-const thenParser = parser.regex(/^(then\s+)((.|\n)*)$/)
-const elseParser = parser.regex(/^(else\s+)((.|\n)*)$/)
+const ifParser = input => parser.regex(/^(if\s+)((.|\n)*)$/)(input)
+const thenParser = input => parser.regex(/^(then\s+)((.|\n)*)$/)(input)
+const elseParser = input => parser.regex(/^(else\s+)((.|\n)*)$/)(input)
 
-const doParser = parser.regex(/^(do)((.|\n)*)$/)
+const doParser = input => parser.regex(/^(do)((.|\n)*)$/)(input)
 
-const returnKeywordParser = parser.regex(/^(return)((.|\n)*)$/)
+const returnKeywordParser = input => parser.regex(/^(return)((.|\n)*)$/)(input)
 
-const returnParser = input => mayBe(
-  returnRegex.exec(input.str),
-  (a, newLine, rest) => returnRest(newLine, input, rest, {'name': 'return', 'value': 1})
+const importKeywordParser = input => parser.regex(/^(import)((.|\n)*)$/)(input)
+
+const definePropParser = input => parser.regex(/^(defineProp)((.|\n)*)$/)(input)
+
+const returnParser = input => maybe(
+  returnRegex().exec(input.str),
+  (m, newLine, rest) => returnRest(newLine, input, rest, {'name': 'return', 'value': 1})
 )
 
-const numberParser = input => mayBe(
-  numRegex.exec(input.str),
-  (a, num, rest) => returnRest(estemplate.literal(num, num), input, rest, {'name': 'column', 'value': num.length})
+const numberParser = input => maybe(
+  numRegex().exec(input.str),
+  (m, num, rest) => returnRest(estemplate.literal(num, num), input, rest, {'name': 'column', 'value': num.length})
 )
 
-const nonReservedIdParser = input => mayBe(
-  idRegex.exec(input.str),
-  (a, name, rest) => (isLanguageConstruct(name) || isIOFunc(name) || isIOMethod(name)) ? null
-    : returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}))
-
-const identifierParser = input => mayBe(
-  idRegex.exec(input.str),
-  (a, name, rest) => returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
+const nonReservedIdParser = input => maybe(
+  idRegex().exec(input.str),
+  (m, name, rest) => (isLanguageConstruct(name) || isIOFunc(name) || isIOMethod(name)) ? null
+    : returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
 )
 
-const ioFuncNameParser = input => mayBe(
-  idRegex.exec(input.str),
-  (a, name, rest) => isIOFunc(name) ? returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}) : null
+const identifierParser = input => maybe(
+  idRegex().exec(input.str),
+  (m, name, rest) => returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
 )
 
-const ioMethodNameParser = input => mayBe(
-  idRegex.exec(input.str),
-  (a, name, rest) => isIOMethod(name) ? returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}) : null
+const ioFuncNameParser = input => maybe(
+  idRegex().exec(input.str),
+  (m, name, rest) => isIOFunc(name) ? returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}) : null
 )
 
-const nullParser = input => mayBe(
-  nullRegex.exec(input.str),
-  (a, val, rest) => returnRest(estemplate.nullLiteral(val), input, rest, {'name': 'column', 'value': 4})
+const ioMethodNameParser = input => maybe(
+  idRegex().exec(input.str),
+  (m, name, rest) => isIOMethod(name) ? returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}) : null
 )
 
-const stringParser = input => mayBe(
-  stringRegex.exec(input.str),
-  (a, string, rest) => returnRest(estemplate.stringLiteral(unescape(string)),
-                                    input, rest, {'name': 'column', 'value': string.length})
+const nullParser = input => maybe(
+  nullRegex().exec(input.str),
+  (m, val, rest) => returnRest(estemplate.nullLiteral(val), input, rest, {'name': 'column', 'value': 4})
 )
 
-const booleanParser = input => mayBe(
-    boolRegex.exec(input.str),
-    (a, bool, rest) => returnRest(estemplate.boolLiteral(bool), input, rest, {'name': 'column', 'value': bool.length})
-  )
-const regexParser = input => {
-  return mayBe(
-  regexRegex.exec(input.str),
-  (a, regex, pattern, b, flags, rest) => returnRest(estemplate.regex(regex, pattern, flags), input, rest,
-                                                {'name': 'column', 'value': pattern.length}))
-}
-const openParensParser = input => mayBe(
-  openParensRegex.exec(input.str),
-  (a, openParens, rest) => returnRest(openParens, input, rest, {'name': 'column', 'value': 1})
+const stringParser = input => maybe(
+  stringRegex().exec(input.str),
+  (m, string, rest) => returnRest(estemplate.stringLiteral(unescape(string)),
+                                  input, rest, {'name': 'column', 'value': string.length})
 )
 
-const closeParensParser = input => mayBe(
-  closeParensRegex.exec(input.str),
-  (a, closeParens, rest) => returnRest(closeParens, input, rest, {'name': 'column', 'value': 1})
+const booleanParser = input => maybe(
+  boolRegex().exec(input.str),
+  (m, bool, rest) => returnRest(estemplate.boolLiteral(bool), input, rest, {'name': 'column', 'value': bool.length})
 )
 
-const openCurlyBraceParser = input => mayBe(
-  openCurlyRegex.exec(input.str),
-  (a, openCurlyBrace, rest) => returnRest(openCurlyBrace, input, rest, {'name': 'column', 'value': openCurlyBrace.length})
+const regexParser = input => maybe(
+  regexRegex().exec(input.str),
+  (m, regex, pattern, b, flags, rest) => returnRest(estemplate.regex(regex, pattern, flags), input, rest,
+                                                    {'name': 'column', 'value': pattern.length})
 )
 
-const closeCurlyBraceParser = input => mayBe(
-  closeCurlyRegex.exec(input.str),
-  (a, closeCurlyBrace, rest) => returnRest(closeCurlyBrace, input, rest, {'name': 'column', 'value': closeCurlyBrace.length})
+const openParensParser = input => maybe(
+  openParensRegex().exec(input.str),
+  (m, openParens, rest) => returnRest(openParens, input, rest, {'name': 'column', 'value': 1})
 )
 
-const openSquareBracketParser = input => mayBe(
-  openSquareBracketRegex.exec(input.str),
-  (a, openSquareBracket, rest) => returnRest(openSquareBracket, input, rest, {'name': 'column', 'value': openSquareBracket.length})
+const closeParensParser = input => maybe(
+  closeParensRegex().exec(input.str),
+  (m, closeParens, rest) => returnRest(closeParens, input, rest, {'name': 'column', 'value': 1})
 )
 
-const closeSquareBracketParser = input => mayBe(
-  closeSquareBracketRegex.exec(input.str),
-  (a, closeSquareBracket, rest) => returnRest(closeSquareBracket, input, rest, {'name': 'column', 'value': closeSquareBracket.length})
+const openCurlyBraceParser = input => maybe(
+  openCurlyRegex().exec(input.str),
+  (m, openCurlyBrace, rest) => returnRest(openCurlyBrace, input, rest, {'name': 'column', 'value': openCurlyBrace.length})
 )
 
-const commaParser = input => mayBe(
-  commaRegex.exec(input.str),
-  (a, comma, rest) => returnRest(comma, input, rest, {'name': 'column', 'value': comma.length})
+const closeCurlyBraceParser = input => maybe(
+  closeCurlyRegex().exec(input.str),
+  (m, closeCurlyBrace, rest) => returnRest(closeCurlyBrace, input, rest, {'name': 'column', 'value': closeCurlyBrace.length})
 )
 
-const colonParser = input => mayBe(
-  colonRegex.exec(input.str),
-  (a, colon, rest) => returnRest(colon, input, rest, {'name': 'column', 'value': colon.length})
+const openSquareBracketParser = input => maybe(
+  openSquareBracketRegex().exec(input.str),
+  (m, openSquareBracket, rest) => returnRest(openSquareBracket, input, rest, {'name': 'column', 'value': openSquareBracket.length})
 )
 
-const singleLineCommentParser = input => mayBe(
-  singleLineCommentRegex.exec(input.str),
-  (a, comment, b, c, d, rest) => {
+const closeSquareBracketParser = input => maybe(
+  closeSquareBracketRegex().exec(input.str),
+  (m, closeSquareBracket, rest) => returnRest(closeSquareBracket, input, rest, {'name': 'column', 'value': closeSquareBracket.length})
+)
+
+const commaParser = input => maybe(
+  commaRegex().exec(input.str),
+  (m, comma, rest) => returnRest(comma, input, rest, {'name': 'column', 'value': comma.length})
+)
+
+const colonParser = input => maybe(
+  colonRegex().exec(input.str),
+  (m, colon, rest) => returnRest(colon, input, rest, {'name': 'column', 'value': colon.length})
+)
+
+const singleLineCommentParser = input => maybe(
+  singleLineCommentRegex().exec(input.str),
+  (...vals) => {
+    let [, comment, , , , rest] = vals
     let val = comment.slice(2, comment.length - 1)
     return returnRest(estemplate.comment('Line', val), input, rest, {'name': 'return', 'value': 1})
   }
 )
 
-const multiLineCommentParser = input => mayBe(
-  multiLineCommentRegex.exec(input.str),
-  (a, comment, b, c, d, e, rest) => {
-    let lineCount = comment.match(/\n/g) === null ? 0 : comment.match(/\n/g).length
+const multiLineCommentParser = input => maybe(
+  multiLineCommentRegex().exec(input.str),
+  (...vals) => {
+    let [, comment, , , , , rest] = vals
+    let lineCount = notNull(comment.match(/\n/g)) ? comment.match(/\n/g).length : 0
     let val = comment.slice(2, comment.length - 2)
     return returnRest(estemplate.comment('Block', val), input, rest, {'name': 'return', 'value': lineCount})
   }
 )
 
-const binaryOperatorParser = input => mayBe(
-  parser.all(mayBeSpace, parser.regex(binaryOperatorRegex), mayBeSpace)(input),
+const binaryOperatorParser = input => maybe(
+  parser.all(maybeSpace, parser.regex(binaryOperatorRegex()), maybeSpace)(input),
   (val, rest) => {
     let [sp1, op, sp2] = val
     return returnRest(op, input, rest.str, {'name': 'column', 'value': (sp1 + op + sp2).length})
   })
 
-const unaryOperatorParser = input => mayBe(
-    unaryOperatorRegex.exec(input.str),
-    (m, operator, rest) => returnRest(operator, input, rest, {'name': 'column', 'value': operator.length})
+const unaryOperatorParser = input => maybe(
+  unaryOperatorRegex().exec(input.str),
+  (m, operator, rest) => returnRest(operator, input, rest, {'name': 'column', 'value': operator.length})
 )
 
-const parenCheck = src => mayBe(parser.regex(/^(\))((.|\n)*)$/)(src),
-                              (m, val, rest) => returnRest(val, src, src.str))
+const parenCheck = src => maybe(
+  parser.regex(/^(\))((.|\n)*)$/)(src),
+  (m, val, rest) => returnRest(val, src, src.str)
+)
 
-const mayBeSpace = input => {
+const maybeSpace = input => {
   let val = ''
   let space = spaceParser(input)
   let rest = input
-  if (space !== null) [val, rest] = space
+  if (notNull(space)) [val, rest] = space
   return returnRest(val, input, rest.str, {name: 'column', value: val.length})
 }
 
-const mayBeNewLine = input => {
-  let val = ''
+const maybeNewLine = input => {
   let result = parser.all(returnParser, spaceParser)(input)
-  let rest = input
-  if (result !== null) {
-    [val, rest] = result
+  if (notNull(result)) {
+    let [val, rest] = result
     let [, indent] = val
     return returnRest(indent, input, rest.str, {name: 'indent', value: indent.length})
   }
   return null
 }
 
-const mayBeNewLineAndIndent = input => parser.any(mayBeNewLine, mayBeSpace)(input)
+const maybeNewLineAndIndent = input => parser.any(maybeNewLine, maybeSpace)(input)
 
-const importKeywordParser = input => parser.regex(/^(import)((.|\n)*)$/)(input)
-
-const libNameParser = input => mayBe(
+const libNameParser = input => maybe(
   parser.regex(/^(node-core|browser-core)((.|\n)*)$/)(input),
   (val, rest) => returnRest(val, input, rest.str)
 )
 
-const importParser = input => mayBe(
+const importParser = input => maybe(
   parser.all(importKeywordParser, spaceParser, libNameParser)(input),
   (val, rest) => returnRest(val[2], input, rest.str)
 )
 
-const deleteKeywordParser = input => mayBe(
-    deleteRegex.exec(input.str),
+const deleteKeywordParser = input => maybe(
+  deleteRegex().exec(input.str),
     (m, operator, rest) => returnRest(operator, input, rest, {'name': 'column', 'value': operator.length})
 )
 
 const emptyArgsParser = input => {
-  let result = parser.all(openParensParser, mayBeSpace, closeParensParser)(input)
-  if (result === null) return null
+  let result = parser.all(openParensParser, maybeSpace, closeParensParser)(input)
+  if (isNull(result)) return null
   let [, rest] = result
   return [[], rest]
 }
@@ -233,8 +241,8 @@ const emptyArgsParser = input => {
 module.exports = {
   returnParser,
   spaceParser,
-  mayBeSpace,
-  mayBeNewLineAndIndent,
+  maybeSpace,
+  maybeNewLineAndIndent,
   numberParser,
   nonReservedIdParser,
   identifierParser,
@@ -271,5 +279,6 @@ module.exports = {
   returnKeywordParser,
   importParser,
   deleteKeywordParser,
-  emptyArgsParser
+  emptyArgsParser,
+  definePropParser
 }

--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -1,7 +1,9 @@
 const types = require('./operatorPrecedence')
+const notNull = require('./utilityFunctions').notNull
+const notUndefined = require('./utilityFunctions').notUndefined
 let estemplate = {}
 
-const extractExpr = token => token !== undefined && token !== null && token.type === 'ExpressionStatement' ? token.expression : token
+const extractExpr = token => notUndefined(token) && notNull(token) && token.type === 'ExpressionStatement' ? token.expression : token
 
 estemplate.import = lib => ({
   'type': 'VariableDeclaration',
@@ -27,73 +29,67 @@ estemplate.import = lib => ({
   'kind': 'const'
 })
 
-estemplate.error = msg => (
-  {
-    'type': 'ExpressionStatement',
-    'expression': {
-      'type': 'CallExpression',
-      'callee': {
-        'type': 'MemberExpression',
-        'computed': false,
-        'object': {
-          'type': 'Identifier',
-          'name': 'console'
-        },
-        'property': {
-          'type': 'Identifier',
-          'name': 'log'
-        }
-      },
-      'arguments': [
-        {
-          'type': 'Literal',
-          'value': msg,
-          'raw': msg
-        }
-      ]
-    }
-  }
-)
-
-estemplate.power = (base, exponent) => (
-  {
+estemplate.error = msg => ({
+  'type': 'ExpressionStatement',
+  'expression': {
     'type': 'CallExpression',
-    'sType': 'number',
-    'isPower': true,
     'callee': {
       'type': 'MemberExpression',
       'computed': false,
       'object': {
         'type': 'Identifier',
-        'name': 'Math'
+        'name': 'console'
       },
       'property': {
         'type': 'Identifier',
-        'name': 'pow'
+        'name': 'log'
       }
     },
-    'arguments': [base, exponent]
-  }
-)
-
-const typeEqual = (first, second) => first.sType === second.sType
-
-estemplate.concat = (val, arg) => (
-  {
-    'type': 'CallExpression',
-    'sType': typeEqual(val, arg) && val.sType === 'string' ? 'string' : 'list',
-    'callee': {
-      'type': 'MemberExpression',
-      'computed': false,
-      'object': val,
-      'property': {
-        'type': 'Identifier',
-        'name': 'concat'
+    'arguments': [
+      {
+        'type': 'Literal',
+        'value': msg,
+        'raw': msg
       }
-    },
-    'arguments': [arg]
+    ]
   }
-)
+})
+
+estemplate.power = (base, exponent) => ({
+  'type': 'CallExpression',
+  'sType': 'number',
+  'isPower': true,
+  'callee': {
+    'type': 'MemberExpression',
+    'computed': false,
+    'object': {
+      'type': 'Identifier',
+      'name': 'Math'
+    },
+    'property': {
+      'type': 'Identifier',
+      'name': 'pow'
+    }
+  },
+  'arguments': [base, exponent]
+})
+
+// const typeEqual = (first, second) => first.sType === second.sType
+
+// estemplate.concat = (val, arg) => ({
+//   'type': 'CallExpression',
+//   'sType': typeEqual(val, arg) && val.sType === 'string' ? 'string' : 'list',
+//   'callee': {
+//     'type': 'MemberExpression',
+//     'computed': false,
+//     'object': val,
+//     'property': {
+//       'type': 'Identifier',
+//       'name': 'concat'
+//     }
+//   },
+//   'arguments': [arg]
+// })
 
 estemplate.ast = () =>
   ({'type': 'Program', 'body': [], 'sourceType': 'script'})
@@ -113,13 +109,6 @@ estemplate.stringLiteral = value =>
 estemplate.identifier = value =>
   ({'type': 'Identifier', 'name': value})
 
-estemplate.assignment = (left, operator, right) => ({
-  'type': 'AssignmentExpression',
-  operator,
-  left,
-  right
-})
-
 estemplate.regex = (regex, pattern, flags) => ({
   'type': 'Literal',
   'value': new RegExp(pattern, flags),
@@ -133,87 +122,76 @@ estemplate.regex = (regex, pattern, flags) => ({
 
 estemplate.declaration = (id, val) => ({
   'type': 'VariableDeclaration',
-  'declarations': [
-    {
-      'type': 'VariableDeclarator',
-      id,
-      'init': extractExpr(val)
-    }
-  ],
+  'declarations': [{
+    'type': 'VariableDeclarator',
+    id,
+    'init': extractExpr(val)
+  }],
   'kind': 'const'
 })
 
-estemplate.funcDeclaration = (id, params, body) =>
-  ({
-    'type': 'VariableDeclaration',
-    'declarations': [
-      {
-        'type': 'VariableDeclarator',
-        id,
-        'init': {
-          'type': 'ArrowFunctionExpression',
-          'id': null,
-          'params': params,
-          'body': extractExpr(body) || '',
-          'generator': false,
-          'expression': (body === undefined || body.type !== 'BlockStatement')
-        }
-      }
-    ],
-    'kind': 'const'
-  })
-
-estemplate.lambdaCall = (params, args, body) =>
-  ({
-    'type': 'CallExpression',
-    'callee': {
+estemplate.funcDeclaration = (id, params, body) => ({
+  'type': 'VariableDeclaration',
+  'declarations': [{
+    'type': 'VariableDeclarator',
+    id,
+    'init': {
       'type': 'ArrowFunctionExpression',
       'id': null,
       'params': params,
       'body': extractExpr(body) || '',
       'generator': false,
       'expression': (body === undefined || body.type !== 'BlockStatement')
-    },
-    'arguments': args.map(extractExpr)
-  }
-  )
-
-estemplate.letExpression = (params, args, body) =>
-  ({
-    'type': 'CallExpression',
-    'callee': {
-      'type': 'ArrowFunctionExpression',
-      'id': null,
-      'params': params,
-      'body': extractExpr(body) || '',
-      'generator': false,
-      'expression': true
-    },
-    'arguments': args.map(extractExpr)
-  }
-  )
-
-estemplate.memberExpression = (obj, prop) =>
-  ({
-    'type': 'ExpressionStatement',
-    'expression': {
-      'type': 'MemberExpression',
-      'computed': false,
-      'object': extractExpr(obj),
-      'property': extractExpr(prop)
     }
-  })
+  }],
+  'kind': 'const'
+})
 
-estemplate.subscriptExpression = (obj, prop) =>
-  ({
-    'type': 'ExpressionStatement',
-    'expression': {
-      'type': 'MemberExpression',
-      'computed': true,
-      'object': extractExpr(obj),
-      'property': extractExpr(prop)
-    }
-  })
+estemplate.lambdaCall = (params, args, body) => ({
+  'type': 'CallExpression',
+  'callee': {
+    'type': 'ArrowFunctionExpression',
+    'id': null,
+    'params': params,
+    'body': extractExpr(body) || '',
+    'generator': false,
+    'expression': (body === undefined || body.type !== 'BlockStatement')
+  },
+  'arguments': args.map(extractExpr)
+})
+
+estemplate.letExpression = (params, args, body) => ({
+  'type': 'CallExpression',
+  'callee': {
+    'type': 'ArrowFunctionExpression',
+    'id': null,
+    'params': params,
+    'body': extractExpr(body) || '',
+    'generator': false,
+    'expression': true
+  },
+  'arguments': args.map(extractExpr)
+})
+
+estemplate.memberExpression = (obj, prop) => ({
+  'type': 'ExpressionStatement',
+  'expression': {
+    'type': 'MemberExpression',
+    'computed': false,
+    'object': extractExpr(obj),
+    'property': extractExpr(prop)
+  }
+})
+
+estemplate.subscriptExpression = (obj, prop) => ({
+  'type': 'ExpressionStatement',
+  'expression': {
+    'type': 'MemberExpression',
+    'computed': true,
+    'object': extractExpr(obj),
+    'property': extractExpr(prop)
+  }
+})
 
 estemplate.printexpression = (args) => ({
   'type': 'ExpressionStatement',
@@ -243,18 +221,17 @@ estemplate.fnCall = (val, args) => val.name === 'print' ? estemplate.printexpres
     arguments: args.map(extractExpr)
   })
 
-estemplate.lambda = (params, body) =>
-  ({
-    'type': 'ExpressionStatement',
-    'expression': {
-      'type': 'ArrowFunctionExpression',
-      'id': null,
-      params,
-      'body': extractExpr(body) || '',
-      'generator': false,
-      'expression': (body === undefined || body.type !== 'BlockStatement')
-    }
-  })
+estemplate.lambda = (params, body) => ({
+  'type': 'ExpressionStatement',
+  'expression': {
+    'type': 'ArrowFunctionExpression',
+    'id': null,
+    params,
+    'body': extractExpr(body) || '',
+    'generator': false,
+    'expression': (body === undefined || body.type !== 'BlockStatement')
+  }
+})
 
 estemplate.binaryExpression = (left, op, right) => {
   let opType = types[op].type
@@ -273,14 +250,12 @@ const binaryExpr = (left, op, right, opType) => ({
   'right': extractExpr(right)
 })
 
-estemplate.unaryExpression = (op, arg) => (
-  {
-    'type': 'UnaryExpression',
-    'operator': op,
-    'argument': extractExpr(arg),
-    'prefix': true
-  }
-)
+estemplate.unaryExpression = (op, arg) => ({
+  'type': 'UnaryExpression',
+  'operator': op,
+  'argument': extractExpr(arg),
+  'prefix': true
+})
 
 estemplate.blockStmt = body => ({
   'type': 'BlockStatement',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,17 +9,22 @@ const base = require('./basicParsers')
 const utils = require('./utilityFunctions')
 /* Utility Functions */
 const {
-  mayBe,
+  maybe,
   returnRest,
   isEmptyObj,
+  isEmptyArr,
+  isNull,
+  isUndefined,
+  notNull,
+  notUndefined,
   precedence,
   associativity
 } = utils
 /* Base Parsers */
 const {
-  returnParser, spaceParser, mayBeSpace, mayBeNewLineAndIndent,
+  returnParser, spaceParser, maybeSpace, maybeNewLineAndIndent,
   numberParser, nonReservedIdParser, identifierParser, nullParser, stringParser, booleanParser,
-  regexParser, openParensParser, closeParensParser,
+  openParensParser, closeParensParser,
   openCurlyBraceParser, closeCurlyBraceParser,
   openSquareBracketParser, closeSquareBracketParser,
   commaParser, colonParser, equalSignParser, thinArrowParser, dotParser,
@@ -29,54 +34,21 @@ const {
   ifParser, thenParser, elseParser,
   slashParser, parenCheck,
   reverseBindParser, doParser, ioFuncNameParser, ioMethodNameParser,
-  returnKeywordParser, deleteKeywordParser, emptyArgsParser
+  returnKeywordParser, deleteKeywordParser, emptyArgsParser, definePropParser
 } = base
 
-const valueParser = input => parser.any(binaryExprParser, fnCallParser, expressionParser)(input)
-
-const parenthesesParser = input => {
-  let result = parser.all(openParensParser, mayBeNewLineAndIndent,
-                          valueParser, mayBeNewLineAndIndent, closeParensParser)(input)
-
-  if (result === null) return null
-  let [[, , val], rest] = result
-  return returnRest(val, input, rest.str)
-}
-
-const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaParser, lambdaCallParser,
-                                             letExpressionParser, ifExprParser, memberExprParser, arrayParser,
-                                             objectParser, booleanParser, nonReservedIdParser, numberParser,
-                                             nullParser, stringParser)(input)
-
-const unaryExprParser = parser.bind(
+const unaryExprParser = input => parser.bind(
   parser.bind(
     unaryOperatorParser,
     operator => rest => operator === ':type'
-      ? spaceParser(rest) !== null ? ['typeof', spaceParser(rest)[1]] : null
+      ? notNull(spaceParser(rest)) ? ['typeof', spaceParser(rest)[1]] : null
       : [operator, rest]),
-  operator => rest => mayBe(expressionParser(rest),
+  operator => rest => maybe(expressionParser(rest),
     (argument, rest) => [estemplate.unaryExpression(operator, argument), rest])
-)
+)(input)
 
-const binaryExprParser = (input, opStack = ['$'], operandStack = [], expect = 'operand') => {
-  let [current, rest] = [null, null] // initialize current and rest of the string to null
-  switch (expect) {
-    case 'operand': {
-      let mayBeOperand = parser.any(fnCallParser, expressionParser)(input);
-      [current, rest] = mayBeOperand !== null ? mayBeOperand : [null, null]
-      return current === null ? null
-                              : binaryExprParser(rest, opStack, operandStack.concat(current), 'operator')
-    }
-    case 'operator': {
-      let mayBeOperator = binaryOperatorParser(input);
-      [current, rest] = mayBeOperator !== null ? mayBeOperator : [null, null]
-      return current === null ? binaryExpr(opStack, operandStack, input, rest)
-        : handleOrder(opStack, operandStack, current, input, rest)
-    }
-  }
-}
-
-const binaryExpr = (opStack, operandStack, input, rest) => {
+/* Helper functions for binaryExprParser */
+const formBinaryExpr = (opStack, operandStack, input, rest) => {
   let opStackTop = opStack[opStack.length - 1]
   if (opStackTop === '$') {
     let binExpr = operandStack.pop()
@@ -84,10 +56,10 @@ const binaryExpr = (opStack, operandStack, input, rest) => {
   }
   let [right, left, op] = [operandStack.pop(), operandStack.pop(), opStack.pop()]
   let expr = estemplate.binaryExpression(left, op, right)
-  return binaryExpr(opStack, operandStack.concat(expr), input, rest)
+  return formBinaryExpr(opStack, operandStack.concat(expr), input, rest)
 }
 
-const handleOrder = (opStack, operandStack, current, input, rest) => {
+const handlePrecAssoc = (opStack, operandStack, current, rest) => {
   let opStackTop = opStack[opStack.length - 1]
   let currentHasHigher = precedence(current) > precedence(opStackTop)
   let currentHasLower = precedence(current) < precedence(opStackTop)
@@ -104,163 +76,291 @@ const handleOrder = (opStack, operandStack, current, input, rest) => {
   }
 }
 
-const declParser = parser.bind(
-  parser.bind(
-    nonReservedIdParser,
-    val => input => mayBe(
-        equalSignParser(input),
-        (v, rest) => [val, rest]
-      )
-  ),
-  val => input => mayBe(
-    valueParser(input),
-        (v, rest) => {
-          return returnRest(estemplate.declaration(val, v), input, rest.str)
-        }
-      )
+const binaryExprParser = (input, opStack = ['$'], operandStack = [], expect = 'operand') => {
+  let [current, rest] = [null, null] // initialize current and rest of the string to null
+  switch (expect) {
+    case 'operand': {
+      let maybeOperand = parser.any(fnCallParser, expressionParser)(input);
+      [current, rest] = notNull(maybeOperand) ? maybeOperand : [null, null]
+      return isNull(current) ? null : binaryExprParser(rest, opStack, operandStack.concat(current), 'operator')
+    }
+    case 'operator': {
+      let maybeOperator = binaryOperatorParser(input);
+      [current, rest] = notNull(maybeOperator) ? maybeOperator : [null, null]
+      return notNull(current) ? handlePrecAssoc(opStack, operandStack, current, rest)
+        : formBinaryExpr(opStack, operandStack, input, rest)
+    }
+  }
+}
+/* binaryExprParser ends */
+
+const ifExprParser = input => maybe(
+  parser.all(
+    ifParser, valueParser,
+    maybeNewLineAndIndent, thenParser, valueParser,
+    maybeNewLineAndIndent, elseParser, valueParser)(input),
+    (val, rest) => {
+      let [, condition, , , consequent, , , alternate] = val
+      return returnRest(estemplate.ifthenelse(condition, consequent, alternate), input, rest.str)
+    }
 )
 
-const paramParser = input => parser.all(spaceParser, parser.any(arrayParser, objectParser, nonReservedIdParser, numberParser, nullParser, stringParser))(input)
-
-const paramsParser = (str, paramArray = []) => {
-  let param = paramParser(str)
-  if (param !== null) {
-    let [[, val], rest] = param
-    return paramsParser(rest, paramArray.concat(val))
-  }
-  return [paramArray, str]
-}
-
-const getLengthOf = params => params.map(p => p.name !== undefined
- ? p.name + ' '
- : p.raw + ' ').join().length
-
-const fnDeclParser = parser.bind(
-  parser.bind(
-    parser.bind(
-      nonReservedIdParser,
-      val => input => mayBe(
-        paramsParser(input),
-        (params, rest) => {
-          let lengthOfParams = getLengthOf(params)
-          return returnRest(estemplate.funcDeclaration(val, params), input, rest.str, {name: 'column', value: lengthOfParams})
-        }
-      )
-    ),
-    val => input => mayBe(
-        equalSignParser(input),
-        (v, rest) => [val, rest]
-      )
-  ),
-  val => input => mayBe(
-    valueParser(input),
-      (body, rest) => {
-        val.declarations[0].init.body = body.type === 'ExpressionStatement' ? body.expression : body
-        return returnRest(val, input, rest.str)
-      }
-    )
-)
-
-const lambdaParamParser = input => parser.all(nonReservedIdParser, spaceParser)(input)
-
-const lambdaParamsParser = (str, lambdaparamArray = []) => {
-  let arg = lambdaParamParser(str)
-  if (arg !== null) {
-    let [[val], rest] = arg
-    return lambdaParamsParser(rest, lambdaparamArray.concat(val))
-  }
-  return [lambdaparamArray, str]
-}
-
-const lambdaParser = parser.bind(
-  parser.bind(
-    parser.bind(
-      slashParser,
-      val => input => mayBe(
-        lambdaParamsParser(input),
-        (params, rest) => returnRest(estemplate.lambda(params), input, rest.str)
-       )
-      ),
-    val => input => mayBe(
-      thinArrowParser(input),
-      (v, rest) => returnRest(val, input, rest.str)
-    )
-   ),
-   val => input => mayBe(
-     valueParser(input),
-     (body, rest) => {
-       val.expression.body = body
-       return returnRest(val, input, rest.str)
-     }
-   )
- )
-
-const lambdaArgParser = input => parser.all(spaceParser, valueParser)(input)
-
-const lambdaArgsParser = (str, lambdaArgsArray = []) => {
-  let arg = lambdaArgParser(str)
-  if (arg !== null) {
-    let [[, val], rest] = arg
-    return lambdaArgsParser(rest, lambdaArgsArray.concat(val))
-  }
-  return [lambdaArgsArray, str]
-}
-
-const lambdaCallParser = input => {
-  let result = parser.all(openParensParser, lambdaParser, closeParensParser, lambdaArgsParser)(input)
-  if (result === null) return null
-  let [[, lambdaAst, , argsArr], rest] = result
-  let {params, body} = lambdaAst.expression
-  let val = estemplate.lambdaCall(params, argsArr, body)
-  return returnRest(val, input, rest.str)
-}
-
-const letParamParser = input => parser.all(nonReservedIdParser, equalSignParser, valueParser, mayBeSpace)(input)
+/* Helper functions for letExpressionParser */
+const letParamParser = input => parser.all(nonReservedIdParser, equalSignParser, valueParser, maybeSpace)(input)
 
 const letParamsParser = (str, letIdArray = [], letLiteralArray = []) => {
   let param = letParamParser(str)
-  if (param !== null) {
+  if (notNull(param)) {
     let [[id,, literal], rest] = param
     return letParamsParser(rest, letIdArray.concat(id), letLiteralArray.concat(literal))
   }
   return [[letIdArray, letLiteralArray], str]
 }
 
-const bindIDParser = (input, idArray = []) => {
-  let result = parser.all(nonReservedIdParser, spaceParser)(input)
-  if (result === null && idArray.length === 0) return null
-  if (result === null) return returnRest(idArray, input, input.str)
-  let [[id], rest] = result
-  return bindIDParser(rest, idArray.concat(id))
+const letExpressionParser = input => parser.bind(
+  parser.bind(
+    parser.bind(
+      letParser,
+      val => input => maybe(
+          letParamsParser(input),
+          (val, rest) => returnRest(estemplate.letExpression(val[0], val[1]), input, rest.str)
+       )
+    ),
+    val => input => maybe(
+        inParser(input),
+        (v, rest) => returnRest(val, input, rest.str)
+      )
+  ),
+  val => input => maybe(
+    valueParser(input),
+      (body, rest) => {
+        val.callee.body = body.type === 'ExpressionStatement' ? body.expression : body
+        return returnRest(val, input, rest.str)
+      }
+    )
+)(input)
+
+/* Helper functions for lambdaParser */
+const paramsParser = (input, idArray = []) => {
+  let param = parser.all(nonReservedIdParser, spaceParser)(input)
+  if (isNull(param)) return [idArray, input]
+  let [[val], rest] = param
+  return paramsParser(rest, idArray.concat(val))
 }
 
-const bindStatementParser = input => parser.all(bindIDParser, reverseBindParser,
-                                                parser.any(fnCallParser, parser.all(
-                                                  ioFuncNameParser,
-                                                  mayBeSpace,
-                                                  argsParser),
-                                                           nonReservedIdParser))(input)
+const lambdaParser = input => parser.bind(
+  parser.bind(
+    parser.bind(
+      slashParser,
+      val => input => maybe(
+        paramsParser(input),
+        (params, rest) => returnRest(estemplate.lambda(params), input, rest.str)
+       )
+      ),
+    val => input => maybe(
+      thinArrowParser(input),
+      (v, rest) => returnRest(val, input, rest.str)
+    )
+   ),
+   val => input => maybe(
+     valueParser(input),
+     (body, rest) => {
+       val.expression.body = body
+       return returnRest(val, input, rest.str)
+     }
+   )
+)(input)
 
-const letStmtParser = input => {
-  let result = parser.all(letParser, letParamsParser)(input)
-  if (result === null) return null
-  let [[, [idArray, valArray]], rest] = result
-  return returnRest([idArray, valArray], input, rest.str)
+/* Helper functions for fnCallParser */
+const argsParser = (input, argArray = []) => {
+  let arg = parser.all(
+    parser.any(unaryExprParser, expressionParser),
+    parser.any(returnParser, parenCheck, spaceParser))(input)
+  if (isNull(arg)) return argArray.length === 0 ? null : [argArray, input]
+  let [[argument, nextChar], rest] = arg
+  if (nextChar === '\n' || nextChar === ')') {
+    rest.str = nextChar === '\n' ? '\n' + rest.str : rest.str
+    return [argArray.concat(argument), rest]
+  }
+  return argsParser(rest, argArray.concat(argument))
 }
 
-const makeMapChain = (idArray, valArray, parentObj) => {
-  if (idArray.length === 0 && valArray.length === 0) return parentObj
-  let cbParams = parentObj.nextParams
-  let cbBody = estemplate.array([valArray[0]].concat(cbParams))
-  let nextParams = [idArray[0]].concat(cbParams)
-  let callBack = estemplate.lambda(cbParams, cbBody).expression
-  let nextParent = estemplate.ioMap(parentObj, callBack, nextParams)
-  return makeMapChain(idArray.slice(1), valArray.slice(1), nextParent)
+const fnCallParser = input => parser.bind(
+  parser.all(parser.any(memberExprParser, nonReservedIdParser), spaceParser),
+  val => input => maybe(
+    parser.any(emptyArgsParser, argsParser)(input),
+      (args, rest) => {
+        let [id] = val
+        let callExpr = estemplate.fnCall(id, args)
+        if (rest.str.startsWith('\n')) return returnRest(estemplate.expression(callExpr), input, rest.str)
+        return returnRest(callExpr, input, rest.str)
+      }
+    )
+)(input)
+
+/* Helper functions for lambdaCallParser */
+const lambdaArgsParser = (input, lambdaArgsArray = []) => {
+  let arg = parser.all(spaceParser, valueParser)(input)
+  if (notNull(arg)) {
+    let [[, val], rest] = arg
+    return lambdaArgsParser(rest, lambdaArgsArray.concat(val))
+  }
+  return [lambdaArgsArray, input]
+}
+
+const lambdaCallParser = input => {
+  let result = parser.all(openParensParser, lambdaParser, closeParensParser, lambdaArgsParser)(input)
+  if (isNull(result)) return null
+  let [[, lambdaAst, , argsArr], rest] = result
+  let {params, body} = lambdaAst.expression
+  let val = estemplate.lambdaCall(params, argsArr, body)
+  return returnRest(val, input, rest.str)
+}
+
+/* Parsers for structures */
+
+/* Helper functions for structure parsers */
+const commaCheck = (input, propArr) => {
+  let [, rest] = maybeSpace(input)
+  let comma = commaParser(rest)
+  if (notNull(comma)) {
+    propArr.push(null)
+    let [, rest] = comma
+    return arrayElemsParser(rest, propArr)
+  }
+  return [propArr, rest]
+}
+
+/* Helper functions for arrayParser */
+const arrayElemParser = input => maybe(
+  parser.all(maybeNewLineAndIndent, valueParser, maybeSpace)(input),
+  (val, rest) => {
+    let [, value] = val
+    return [value, rest]
+  }
+)
+
+const arrayElemsParser = (input, propArr = []) => {
+  let result = arrayElemParser(input)
+  if (isNull(result)) return commaCheck(input, propArr)
+  let [val, rest] = result
+  propArr.push(val)
+  let comma = commaParser(rest)
+  if (isNull(comma)) return [propArr, rest]
+  let [, _rest] = comma
+  return arrayElemsParser(_rest, propArr)
+}
+
+const arrayParser = input => {
+  let openSquareBracket = openSquareBracketParser(input)
+  if (isNull(openSquareBracket)) return null
+  let [, rest] = openSquareBracket
+  let result = arrayElemsParser(rest)
+  if (isNull(result)) return null
+  let [arrayPropAst, arrayPropsRest] = result
+  let closeSquareBracket = parser.all(maybeNewLineAndIndent, closeSquareBracketParser)(arrayPropsRest)
+  if (isNull(closeSquareBracket)) { return null }
+  [, rest] = closeSquareBracket
+  return [estemplate.array(arrayPropAst), rest]
+}
+
+/* Helper functions for objectParser */
+const keyParser = input => parser.any(identifierParser, stringParser, numberParser)(input)
+
+const objectPropParser = input => maybe(
+  parser.all(maybeNewLineAndIndent, keyParser,
+             maybeSpace, colonParser,
+             maybeSpace, valueParser, maybeSpace)(input),
+  (val, rest) => {
+    let [ , key, , , , value, , ] = val
+    return [estemplate.objectProperty(key, value), rest]
+  }
+)
+
+const objectPropsParser = (input, propArr = []) => {
+  let result = objectPropParser(input)
+  if (isNull(result)) return [propArr, input]
+  let [val, rest] = result
+  propArr.push(val)
+  let commaResult = commaParser(rest)
+  if (isNull(commaResult)) { return [propArr, rest] }
+  [, rest] = commaResult
+  let closeCurlyBrace = closeCurlyBraceParser(rest)
+  if (notNull(closeCurlyBrace)) return null
+  return objectPropsParser(rest, propArr)
+}
+
+const objectParser = input => {
+  let openCurlyResult = openCurlyBraceParser(input)
+  if (isNull(openCurlyResult)) return null
+  let [, rest] = openCurlyResult
+  let result = objectPropsParser(rest)
+  if (isNull(result)) return null
+  let [objPropArray, objPropsRest] = result
+  let closeCurlyResult = parser.all(maybeSpace, maybeNewLineAndIndent, closeCurlyBraceParser)(objPropsRest)
+  if (isNull(closeCurlyResult)) { return null }
+  [, rest] = closeCurlyResult
+  return [estemplate.object(objPropArray), rest]
+}
+/* end of structure parsers */
+
+/* Helper functions for memberExprParser */
+const formMemberExpression = (input, obj) => {
+  let prop = parser.any(dotParser, subscriptParser, identifierParser)(input)
+  if (isNull(prop)) return returnRest(obj, input, input.str)
+  let [exp, rest] = prop
+  if (exp.isSubscript) return formMemberExpression(rest, estemplate.subscriptExpression(obj, exp))
+  exp.isSubscript = false
+  if (exp.type === 'Identifier') return formMemberExpression(rest, estemplate.memberExpression(obj, exp))
+  return formMemberExpression(rest, obj)
+}
+
+const subscriptParser = input => {
+  let result = parser.all(openSquareBracketParser,
+                          parser.any(memberExprParser, nonReservedIdParser,
+                                     numberParser, stringParser),
+                          closeSquareBracketParser)(input)
+  if (notNull(result)) {
+    let [[, prop], rest] = result
+    prop.isSubscript = true
+    return returnRest(prop, input, rest.str)
+  }
+  return null
+}
+
+const memberExprParser = input => {
+  let parentObj = parser.any(arrayParser, nonReservedIdParser, parenthesesParser)(input)
+  if (isNull(parentObj)) return null
+  let [obj, rest] = parentObj
+  let result = formMemberExpression(rest, obj)
+  let [memExpr, _rest] = result
+  memExpr = memExpr.type === 'ExpressionStatement' ? memExpr.expression : memExpr
+  return memExpr.type === 'MemberExpression' ? returnRest(memExpr, input, _rest.str) : null
+}
+
+/* IO parsers */
+
+const ioFuncName = input => parser.all(ioFuncNameParser, spaceParser, argsParser)(input)
+
+const doBlockParser = input => {
+  let result = parser.all(doParser, ioBodyParser)(input)
+  if (isNull(result)) return null
+  let [[, doBlock], rest] = result
+  return returnRest(estemplate.expression(doBlock), input, rest.str)
+}
+
+const doFuncParser = input => {
+  let result = parser.all(nonReservedIdParser, funcParamsParser, equalSignParser, doBlockParser)(input)
+  if (isNull(result)) return null
+  let [[funcId, params, , funcBody], rest] = result
+  let val = estemplate.funcDeclaration(funcId, params, funcBody)
+  val.sType = 'IO'
+  return returnRest(val, input, rest.str)
 }
 
 const ioStmtParser = (input, parentObj) => {
-  let result = parser.all(ioFuncNameParser, spaceParser, argsParser)(input)
-  if (result === null) return null
+  let result = ioFuncName(input)
+  if (isNull(result)) return null
   let [[id, , args], rest] = result
   if (isEmptyObj(parentObj)) {
     let val = estemplate.ioCall(id, args)
@@ -271,431 +371,360 @@ const ioStmtParser = (input, parentObj) => {
   return returnRest(val, input, rest.str)
 }
 
-const getCbBody = (thenBody, parentObj) => {
-  if (thenBody.length === 0) return parentObj
-  let callBack = estemplate.lambda(parentObj.nextParams, thenBody[0]).expression
-  let val = estemplate.ioBind(parentObj, callBack, parentObj.nextParams)
-  val.nextParams = parentObj.nextParams
-  return getCbBody(thenBody.slice(1), val)
-}
-
-const handlerParser = input => {
-  let result = parser.all(openParensParser,
-                          parser.any(
-                            fnCallParser,
-                            parser.all(ioFuncNameParser, spaceParser, argsParser),
-                            lambdaCallParser),
-                          closeParensParser)(input)
-  if (result === null) return null
-  let [[, val], rest] = result
-  return returnRest(val, input, rest.str)
-}
-
-const mayBeStmtParser = input => parser.all(ioMethodNameParser, spaceParser, expressionParser, spaceParser, handlerParser)(input)
-
-const defineStmtParser = input => {
-  let result = parser.all(nonReservedIdParser, spaceParser, parser.any(memberExprParser, nonReservedIdParser), spaceParser, stringParser, spaceParser, valueParser)(input)
-  if (result === null) return null
-  let [val, rest] = result
-  let [id] = val
-  if (id.name !== 'defineProp') return null
-  return returnRest(val, input, rest.str)
-}
-
-const deleteStmtParser = input => parser.all(deleteKeywordParser, spaceParser, parser.any(memberExprParser, nonReservedIdParser))(input)
-
-const getIOBody = (input, parentObj = {}, thenBody = []) => {
-  let finalStmt = returnParser(input)
-  if (finalStmt !== null) {
-    let [, rest] = finalStmt
-    let result = spaceParser(rest)
-    if (result === null) {
-      if (isEmptyObj(parentObj) && thenBody.length === 0) return null
-      if (isEmptyObj(parentObj) && thenBody.length !== 0) {
-        parentObj = getCbBody(thenBody.slice(1), thenBody[0])
-        let val = estemplate.defaultIOThen(parentObj)
-        return returnRest(val, input, rest.str)
-      }
-
-      let cbParams = parentObj.nextParams === undefined ? [] : parentObj.nextParams
-      let cbBody = thenBody
-      if (parentObj.returnVals !== undefined) {
-        parentObj = getCbBody(cbBody, parentObj)
-        let returnVals = parentObj.returnVals
-        let callBack = estemplate.lambda(cbParams, estemplate.array(returnVals)).expression
-        let val = estemplate.lambda([], estemplate.ioMap(parentObj, callBack, cbParams)).expression
-        val.sType = 'IO'
-        return returnRest(val, input, rest.str)
-      } else {
-        parentObj = getCbBody(thenBody, parentObj)
-        let cbBody = estemplate.array(thenBody)
-        let callBack = estemplate.lambda(cbParams, cbBody).expression
-        let val = estemplate.ioThen(parentObj, callBack, cbParams)
-        val.sType = 'IO'
-        return returnRest(val, input, rest.str)
-      }
-    }
-
-    [, rest] = result
-    let mayBeReturn = parser.all(returnKeywordParser, spaceParser, argsParser)(rest)
-
-    if (mayBeReturn !== null) {
-      [[, , parentObj.returnVals], rest] = mayBeReturn
-    }
-    return getIOBody(rest, parentObj, thenBody)
-  }
-
-  let mayBeBind = bindStatementParser(input)
-  if (mayBeBind !== null) {
-    let [[bindID, , mayBeIOFunc], rest] = mayBeBind
-    let nextParams = parentObj.nextParams === undefined ? bindID : parentObj.nextParams.concat(bindID)
-    let isFuncCall = mayBeIOFunc.type !== undefined && mayBeIOFunc.expression !== undefined && mayBeIOFunc.expression.type === 'CallExpression'
-    let isIOCall = mayBeIOFunc.type !== undefined && mayBeIOFunc.type === 'Identifier'
-    if (isIOCall) mayBeIOFunc = estemplate.fnCall(mayBeIOFunc, [])
-    let [ioFunc, , args] = isIOCall || isFuncCall ? [null, null, null] : mayBeIOFunc
-
-    if (ioFunc !== null && ioFunc.name === 'IO' && args[0].type === 'CallExpression') {
-      let [func] = args
-      let cb = estemplate.identifier('cb')
-      ioFunc.name = 'createIO'
-      func.arguments = func.arguments.concat(cb)
-      args = [estemplate.lambda([cb], func).expression]
-    }
-
-    if (isEmptyObj(parentObj)) {
-      let val = isIOCall || isFuncCall ? mayBeIOFunc : estemplate.ioMap(estemplate.ioCall(ioFunc, args, nextParams),
-                                         estemplate.lambda(nextParams, estemplate.array(nextParams)),
-                                         nextParams)
-      if (isFuncCall) val = val.expression
-      val.nextParams = isIOCall || isFuncCall ? nextParams : val.nextParams
-      return getIOBody(rest, val, thenBody)
-    }
-    let cbBody = isIOCall || isFuncCall ? mayBeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
-    if (isFuncCall) cbBody = cbBody.expression
-    cbBody.nextParams = isIOCall ? nextParams : cbBody.nextParams
-    let cbParams = parentObj.nextParams
-    let callBack = estemplate.lambda(cbParams, cbBody)
-    return getIOBody(rest, estemplate.ioBind(parentObj, callBack, nextParams), thenBody)
-  }
-
-  let mayBeDefineProp = defineStmtParser(input)
-  if (mayBeDefineProp !== null && !isEmptyObj(parentObj)) {
-    let [[, , objID, , key, , value], rest] = mayBeDefineProp
-    let defineProp = estemplate.defineProp(objID, key, value)
-    let nextParams = parentObj.nextParams
-    let returnVal = estemplate.returnStmt(nextParams)
-    let cbBody = estemplate.blockStmt([defineProp, returnVal])
-    let callBack = estemplate.lambda(nextParams, cbBody)
-    let val = estemplate.ioMap(parentObj, callBack, nextParams)
-    return getIOBody(rest, val, thenBody)
-  }
-
-  let mayBeDelete = deleteStmtParser(input)
-  if (mayBeDelete !== null && !isEmptyObj(parentObj)) {
-    let [[deleteKeyword, , objProp], rest] = mayBeDelete
-    let deleteStmt = estemplate.unaryExpression(deleteKeyword, objProp)
-    let nextParams = parentObj.nextParams
-    let returnVal = estemplate.returnStmt(nextParams)
-    let cbBody = estemplate.blockStmt([deleteStmt, returnVal])
-    let callBack = estemplate.lambda(nextParams, cbBody)
-    let val = estemplate.ioMap(parentObj, callBack, nextParams)
-    return getIOBody(rest, val, thenBody)
-  }
-
-  let mayBeLet = letStmtParser(input)
-  if (mayBeLet !== null && !isEmptyObj(parentObj)) {
-    let [[idArray, valArray], rest] = mayBeLet
-    let mapChain = makeMapChain(idArray, valArray, parentObj)
-    return getIOBody(rest, mapChain, thenBody)
-  }
-
-  let mayBeStmt = mayBeStmtParser(input)
-  if (mayBeStmt !== null && !isEmptyObj(parentObj)) {
-    let [[methodName, , value, , handler], rest] = mayBeStmt
-    let args = []
-    let nextParams = parentObj.nextParams
-    let handlerBody = handler
-    if (Array.isArray(handler)) {
-      let [ioFunc, , _args] = handler
-      args = _args
-      handler = ioFunc
-      handlerBody = estemplate.defaultIOThen(estemplate.ioCall(handler, args))
-    }
-    let handler_ = estemplate.lambda(nextParams, handlerBody).expression
-    let mayBeVal = estemplate.lambda(nextParams, value).expression
-    let val = estemplate.ioMayBe(parentObj, methodName, [mayBeVal, handler_], nextParams)
-    return getIOBody(rest, val, thenBody)
-  }
-
-  let mayBeIOStmt = ioStmtParser(input, parentObj)
-  if (mayBeIOStmt !== null) {
-    let [val, rest] = mayBeIOStmt
-    return getIOBody(rest, val, thenBody)
-  }
-
-  let mayBeFuncCall = fnCallParser(input)
-  if (mayBeFuncCall !== null && !isEmptyObj(parentObj)) {
-    let [fnCall, rest] = mayBeFuncCall
-    let nextParams = parentObj.nextParams
-    let val = estemplate.ioMap(parentObj,
-                               estemplate.lambda(
-                                 nextParams,
-                                 estemplate.blockStmt([fnCall.expression, estemplate.returnStmt(nextParams)])),
-                               nextParams)
-    return getIOBody(rest, val, thenBody)
-  }
-
-  let mayBeIOCall = nonReservedIdParser(input)
-  if (mayBeIOCall !== null) {
-    let [ioID, rest] = mayBeIOCall
-    if (isEmptyObj(parentObj)) {
-      ioID.nextParams = []
-    }
-    let val = ioID
-    return getIOBody(rest, parentObj, thenBody.concat(val))
-  }
-
-  return null
-}
-
 const noArgsCallParser = input => {
-  let result = parser.all(
-    parser.any(memberExprParser, parenthesesParser, nonReservedIdParser),
-    spaceParser, openParensParser, closeParensParser
-  )(input)
-  if (result === null) return null
+  let result = parser.all(parser.any(memberExprParser,
+                                     parenthesesParser,
+                                     nonReservedIdParser),
+                          spaceParser, openParensParser, closeParensParser)(input)
+  if (isNull(result)) return null
   let [[callee], rest] = result
   return returnRest(estemplate.fnCall(callee, []), input, rest.str)
 }
 
-const ioParser = input => {
-  let initIO = parser.all(nonReservedIdParser, equalSignParser, parser.any(doParser, noArgsCallParser, ioStmtParser, nonReservedIdParser))(input)
-  if (initIO === null) return null
-  let [[doID, , mayBeDo], rest] = initIO
-  if (mayBeDo.type !== undefined && mayBeDo.type === 'Identifier' && doID.name !== 'main') return null
-  if (mayBeDo.type !== undefined && mayBeDo.type === 'CallExpression' && doID.name !== 'main') {
-    let val = mayBeDo
-    val.sType = 'IO'
-    return returnRest(estemplate.declaration(doID, val), input, rest.str)
+/* Helper functions for bindStatementParser */
+const bindIDParser = input => {
+  let result = paramsParser(input)
+  return isEmptyArr(result[0]) ? null : result
+}
+
+const maybeBindStmt = input => (parser.all(bindIDParser, reverseBindParser, parser.any(fnCallParser, ioFuncName, nonReservedIdParser))(input))
+
+const mapIOCall = (ioFunc, args, nextParams) => estemplate.ioMap(estemplate.ioCall(ioFunc, args, nextParams),
+                                                                 estemplate.lambda(nextParams,
+                                                                                   estemplate.array(nextParams)),
+                                                                 nextParams)
+
+const isIOorFuncCall = maybeIOFunc => {
+  let isFuncCall = notUndefined(maybeIOFunc.type, maybeIOFunc.expression) && maybeIOFunc.expression.type === 'CallExpression'
+  let isIOCall = notUndefined(maybeIOFunc.type) && maybeIOFunc.type === 'Identifier'
+  return [isFuncCall, isIOCall]
+}
+
+const createIOBody = (args, ioFunc) => {
+  let [func] = args
+  let cb = estemplate.identifier('cb')
+  ioFunc.name = 'createIO'
+  func.arguments = func.arguments.concat(cb)
+  return [estemplate.lambda([cb], func)]
+}
+
+const makeBind = (isIOorFunc, isIOCall, maybeIOFunc, ioFunc, args, nextParams) => {
+  let cbBody = isIOorFunc ? maybeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
+  cbBody.nextParams = isIOCall ? nextParams : cbBody.nextParams
+  return cbBody
+}
+
+const formBindStmt = (cbBody, parentObj, nextParams, rest, bindBody) => {
+  let cbParams = parentObj.nextParams
+  let callBack = estemplate.lambda(cbParams, cbBody)
+  return ioBodyParser(rest, estemplate.ioBind(parentObj, callBack, nextParams), bindBody)
+}
+
+const bindStmt = (maybeBind, parentObj, bindBody) => {
+  let [[bindID, , maybeIOFunc], rest] = maybeBind
+  let nextParams = isUndefined(parentObj.nextParams) ? bindID : parentObj.nextParams.concat(bindID)
+  let [isFuncCall, isIOCall] = isIOorFuncCall(maybeIOFunc)
+  let isIOorFunc = isFuncCall || isIOCall
+  if (isIOCall) maybeIOFunc = estemplate.fnCall(maybeIOFunc, [])
+  let [ioFunc, , args] = isIOorFunc ? [null, null, null] : maybeIOFunc
+  let isNewIO = notNull(ioFunc) && ioFunc.name === 'IO' && args[0].type === 'CallExpression'
+  if (isNewIO) args = createIOBody(args, ioFunc)
+
+  if (isEmptyObj(parentObj)) {
+    let val = isIOorFunc ? maybeIOFunc : mapIOCall(ioFunc, args, nextParams)
+    val.nextParams = isIOorFunc ? nextParams : val.nextParams
+    return ioBodyParser(rest, val, bindBody)
+  }
+  let cbBody = makeBind(isIOorFunc, isIOCall, maybeIOFunc, ioFunc, args, nextParams)
+  return formBindStmt(cbBody, parentObj, nextParams, rest, bindBody)
+}
+
+/* letStmtParser in IO */
+const maybeLetStmt = (input, parentObj, bindBody) => maybe(
+  parser.all(letParser, letParamsParser)(input),
+  (val, rest) => {
+    let [, [idArray, valArray]] = val
+    let mapChain = makeMapChain(idArray, valArray, parentObj)
+    return ioBodyParser(rest, mapChain, bindBody)
+  }
+)
+
+const makeMapChain = (idArray, valArray, parentObj) => {
+  if (idArray.length === 0 && valArray.length === 0) return parentObj
+  let cbParams = parentObj.nextParams
+  let cbBody = estemplate.array([valArray[0]].concat(cbParams))
+  let nextParams = [idArray[0]].concat(cbParams)
+  let callBack = estemplate.lambda(cbParams, cbBody)
+  let nextParent = estemplate.ioMap(parentObj, callBack, nextParams)
+  return makeMapChain(idArray.slice(1), valArray.slice(1), nextParent)
+}
+/* letStmtParser ends here */
+
+/* maybe<Val> parser */
+const handlerParser = input => {
+  let result = parser.all(openParensParser,
+                          parser.any(fnCallParser, ioFuncName, lambdaCallParser),
+                          closeParensParser)(input)
+  if (isNull(result)) return null
+  let [[, val], rest] = result
+  return returnRest(val, input, rest.str)
+}
+
+const maybeStmtParser = (input, parentObj, bindBody) => maybe(
+  parser.all(ioMethodNameParser, spaceParser, expressionParser, spaceParser, handlerParser)(input),
+  (val, rest) => maybeStmt(val, rest, parentObj, bindBody)
+)
+
+const maybeStmt = (maybeVal, rest, parentObj, bindBody) => {
+  let [methodName, , value, , handler] = maybeVal
+  let nextParams = parentObj.nextParams
+  let handlerBody = handler
+  if (Array.isArray(handler)) {
+    let [ioFunc, , args] = handler
+    handler = ioFunc
+    handlerBody = estemplate.defaultIOThen(estemplate.ioCall(handler, args))
+  }
+  let handler_ = estemplate.lambda(nextParams, handlerBody)
+  let maybeValue = estemplate.lambda(nextParams, value)
+  let val = estemplate.ioMayBe(parentObj, methodName, [maybeValue, handler_], nextParams)
+  return ioBodyParser(rest, val, bindBody)
+}
+/* maybe<val> parser ends here */
+
+/* Handler function for delete and defineProp */
+const makeMap = (stmt, parentObj, rest, bindBody) => {
+  let nextParams = parentObj.nextParams
+  let returnVal = estemplate.returnStmt(nextParams)
+  let cbBody = estemplate.blockStmt([stmt, returnVal])
+  let callBack = estemplate.lambda(nextParams, cbBody)
+  let val = estemplate.ioMap(parentObj, callBack, nextParams)
+  return ioBodyParser(rest, val, bindBody)
+}
+
+/* defineProp and delete parsers */
+const maybeDefineStmt = (input, parentObj, bindBody) => maybe(
+  parser.all(definePropParser, spaceParser,
+             parser.any(memberExprParser, nonReservedIdParser), spaceParser,
+             stringParser, spaceParser, valueParser)(input),
+  (val, rest) => {
+    let [, , objID, , key, , value] = val
+    let definePropTmpl = estemplate.defineProp(objID, key, value)
+    return makeMap(definePropTmpl, parentObj, rest, bindBody)
+  }
+)
+
+const maybeDeleteStmt = (input, parentObj, bindBody) => maybe(
+  parser.all(deleteKeywordParser, spaceParser, parser.any(memberExprParser, nonReservedIdParser))(input),
+  (val, rest) => {
+    let [deleteKeyword, , objProp] = val
+    let deleteTmpl = estemplate.unaryExpression(deleteKeyword, objProp)
+    return makeMap(deleteTmpl, parentObj, rest, bindBody)
+  }
+)
+/* defineProp and delete ends here */
+
+/* make final statement */
+const getCbBody = (bindBody, parentObj) => {
+  if (bindBody.length === 0) return parentObj
+  let callBack = estemplate.lambda(parentObj.nextParams, bindBody[0])
+  let val = estemplate.ioBind(parentObj, callBack, parentObj.nextParams)
+  val.nextParams = parentObj.nextParams
+  return getCbBody(bindBody.slice(1), val)
+}
+
+const makeFinalStmt = (input, rest, parentObj, bindBody) => {
+  if (isEmptyObj(parentObj) && bindBody.length === 0) return null
+  if (isEmptyObj(parentObj) && bindBody.length !== 0) {
+    parentObj = getCbBody(bindBody.slice(1), bindBody[0])
+    let val = estemplate.defaultIOThen(parentObj)
+    return returnRest(val, input, rest.str)
   }
 
-  let ioBody
-  if (mayBeDo === 'do') {
-    let result = getIOBody(rest)
-    if (result === null) { return null }
-    [ioBody, rest] = result
-    ioBody.expression = false
+  let cbParams = isUndefined(parentObj.nextParams) ? [] : parentObj.nextParams
+  parentObj = getCbBody(bindBody, parentObj)
+  let cbBody = isUndefined(parentObj.returnVals) ? estemplate.array(bindBody) : estemplate.array(parentObj.returnVals)
+  let callBack = estemplate.lambda(cbParams, cbBody)
+  let val
+  if (isUndefined(parentObj.returnVals)) {
+    val = estemplate.ioThen(parentObj, callBack, cbParams)
   } else {
-    ioBody = estemplate.defaultIOThen(estemplate.fnCall(mayBeDo, []))
+    val = estemplate.lambda([], estemplate.ioMap(parentObj, callBack, cbParams)).expression // need .expression here
   }
-
-  ioBody.sType = 'IO'
-  let val = estemplate.declaration(doID, ioBody)
   val.sType = 'IO'
   return returnRest(val, input, rest.str)
 }
+/* final statement ends here */
 
-const doBlockParser = input => {
-  let result = parser.all(doParser, getIOBody)(input)
-  if (result === null) return null
-  let [[, doBlock], rest] = result
-  return returnRest(estemplate.expression(doBlock), input, rest.str)
-}
-
-const doFuncParser = input => {
-  let result = parser.all(nonReservedIdParser, paramsParser, equalSignParser, doBlockParser)(input)
-  if (result === null) return null
-  let [[funcId,params, , funcBody], rest] = result
-  let val = estemplate.funcDeclaration(funcId, params, funcBody.expression)
-  val.sType = 'IO'
-  return returnRest(val, input, rest.str)
-}
-
-const letExpressionParser = parser.bind(
-  parser.bind(
-    parser.bind(
-      letParser,
-      val => input => mayBe(
-          letParamsParser(input),
-          (val, rest) => returnRest(estemplate.letExpression(val[0], val[1]), input, rest.str)
-       )
-    ),
-    val => input => mayBe(
-        inParser(input),
-        (v, rest) => returnRest(val, input, rest.str)
-      )
-  ),
-  val => input => mayBe(
-    valueParser(input),
-      (body, rest) => {
-        val.callee.body = body.type === 'ExpressionStatement' ? body.expression : body
-        return returnRest(val, input, rest.str)
-      }
-    )
-  )
-
-const formMemberExpression = (input, obj) => {
-  let prop = parser.any(dotParser, subscriptParser, identifierParser)(input)
-  if (prop === null) return returnRest(obj, input, input.str)
-  let [exp, rest] = prop
-  if (exp.isSubscript) return formMemberExpression(rest, estemplate.subscriptExpression(obj, exp))
-  exp.isSubscript = false
-  if (exp.type === 'Identifier') return formMemberExpression(rest, estemplate.memberExpression(obj, exp))
-  return formMemberExpression(rest, obj)
-}
-
-const memberExprParser = input => {
-  let parentObj = parser.any(arrayParser, nonReservedIdParser, parenthesesParser)(input)
-  if (parentObj === null) return null
-  let [obj, rest] = parentObj
-  let result = formMemberExpression(rest, obj)
-  let [memExpr, _rest] = result
-  memExpr = memExpr.type === 'ExpressionStatement' ? memExpr.expression : memExpr
-  return memExpr.type === 'MemberExpression' ? returnRest(memExpr, input, _rest.str) : null
-}
-
-const subscriptParser = input => {
-  let result = parser.all(
-  openSquareBracketParser,
-  parser.any(memberExprParser, nonReservedIdParser, numberParser, stringParser),
-    closeSquareBracketParser)(input)
-  if (result !== null) {
-    let [[, prop], rest] = result
-    prop.isSubscript = true
-    return returnRest(prop, input, rest.str)
+const maybeFinalStmt = (finalStmt, input, parentObj, bindBody) => {
+  let [, rest] = finalStmt
+  let result = spaceParser(rest)
+  if (isNull(result)) {
+    return makeFinalStmt(input, rest, parentObj, bindBody)
   }
+  [, rest] = result
+  let maybeReturn = parser.all(returnKeywordParser, spaceParser, argsParser)(rest)
+  if (notNull(maybeReturn)) [[, , parentObj.returnVals], rest] = maybeReturn
+  return ioBodyParser(rest, parentObj, bindBody)
+}
+
+const maybeFuncCallStmt = (input, parentObj, bindBody) => maybe(
+  fnCallParser(input),
+  (fnCall, rest) => {
+    let nextParams = parentObj.nextParams
+    let val = estemplate.ioMap(parentObj,
+                               estemplate.lambda(nextParams, estemplate.blockStmt([fnCall, estemplate.returnStmt(nextParams)])),
+                               nextParams)
+    return ioBodyParser(rest, val, bindBody)
+  }
+)
+
+const maybeIOCallStmt = (maybeIOCall, parentObj, bindBody) => {
+  let [ioID, rest] = maybeIOCall
+  if (isEmptyObj(parentObj)) ioID.nextParams = []
+  let val = ioID
+  return ioBodyParser(rest, parentObj, bindBody.concat(val))
+}
+
+const ioBodyParser = (input, parentObj = {}, bindBody = []) => {
+  let finalStmt = returnParser(input)
+  if (notNull(finalStmt)) return maybeFinalStmt(finalStmt, input, parentObj, bindBody)
+
+  let bind = maybeBindStmt(input)
+  if (notNull(bind)) return bindStmt(bind, parentObj, bindBody)
+
+  if (!isEmptyObj(parentObj)) {
+    let val = parser.any(maybeDefineStmt, maybeDeleteStmt, maybeLetStmt, maybeStmtParser, maybeFuncCallStmt)(input, parentObj, bindBody)
+    if (val !== null) return val
+  }
+
+  let ioStmt = ioStmtParser(input, parentObj)
+  if (notNull(ioStmt)) return ioBodyParser(ioStmt[1], ioStmt[0], bindBody)
+
+  let ioCall = nonReservedIdParser(input)
+  if (notNull(ioCall)) return maybeIOCallStmt(ioCall, parentObj, bindBody)
+
   return null
 }
 
-const argsParser = (input, argArray = []) => {
-  let arg = parser.all(
-    parser.any(unaryExprParser, expressionParser),
-    parser.any(returnParser, parenCheck, spaceParser))(input)
-  if (arg === null) return argArray.length === 0 ? null : [argArray, input]
-  let [[argument, nextChar], rest] = arg
-  if (nextChar === '\n' || nextChar === ')') {
-    rest.str = nextChar === '\n' ? '\n' + rest.str : rest.str
-    return [argArray.concat(argument), rest]
+const ioDecl = (maybeDo, doID, input, rest) => {
+  let ioBody
+  if (maybeDo === 'do') {
+    let result = ioBodyParser(rest)
+    if (isNull(result)) { return null }
+    [ioBody, rest] = result
+    ioBody.expression = false
+  } else {
+    ioBody = estemplate.defaultIOThen(estemplate.fnCall(maybeDo, []))
   }
-  return argsParser(rest, argArray.concat(argument))
+  ioBody.sType = 'IO'
+  let val = estemplate.declaration(doID, ioBody)
+  return returnRest(val, input, rest.str)
 }
 
-const fnCallParser = parser.bind(
-  parser.all(parser.any(memberExprParser, nonReservedIdParser), spaceParser),
-  val => input => mayBe(
-    parser.any(emptyArgsParser, argsParser)(input),
-      (args, rest) => {
-        let [id] = val
-        let callExpr = estemplate.fnCall(id, args)
-        if (rest.str.startsWith('\n')) return returnRest(estemplate.expression(callExpr), input, rest.str)
-        return returnRest(callExpr, input, rest.str)
+const ioParser = input => {
+  let initIO = parser.all(nonReservedIdParser, equalSignParser,
+                          parser.any(doParser, noArgsCallParser,
+                                     ioStmtParser, nonReservedIdParser)
+                         )(input)
+  if (isNull(initIO)) return null
+  let [[doID, , maybeDo], rest] = initIO
+  let idNotMain = notUndefined(maybeDo.type) && maybeDo.type === 'Identifier' && doID.name !== 'main'
+  if (idNotMain) return null
+
+  let funcNotMain = notUndefined(maybeDo.type) && maybeDo.type === 'CallExpression' && doID.name !== 'main'
+  if (funcNotMain) {
+    let val = maybeDo
+    val.sType = 'IO'
+    return returnRest(estemplate.declaration(doID, val), input, rest.str)
+  }
+  return ioDecl(maybeDo, doID, input, rest)
+}
+/* IO ends here */
+
+const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaParser, lambdaCallParser,
+                                             letExpressionParser, ifExprParser, memberExprParser, arrayParser,
+                                             objectParser, booleanParser, nonReservedIdParser, numberParser,
+                                             nullParser, stringParser)(input)
+
+const parenthesesParser = input => {
+  let result = parser.all(openParensParser, maybeNewLineAndIndent,
+                          valueParser, maybeNewLineAndIndent, closeParensParser)(input)
+  if (isNull(result)) return null
+  let [[, , val], rest] = result
+  return returnRest(val, input, rest.str)
+}
+
+const valueParser = input => parser.any(binaryExprParser, fnCallParser, expressionParser)(input)
+
+const declParser = input => parser.bind(
+  parser.bind(
+    nonReservedIdParser,
+    val => input => maybe(
+        equalSignParser(input),
+        (v, rest) => [val, rest]
+      )
+  ),
+  val => input => maybe(
+    valueParser(input),
+        (v, rest) => {
+          return returnRest(estemplate.declaration(val, v), input, rest.str)
+        }
+      )
+)(input)
+
+/* Helper for fnDeclParser */
+const funcParamsParser = (input, paramArray = []) => {
+  let param = parser.all(spaceParser, parser.any(arrayParser, objectParser, nonReservedIdParser, numberParser, nullParser, stringParser))(input)
+  if (notNull(param)) {
+    let [[, val], rest] = param
+    return funcParamsParser(rest, paramArray.concat(val))
+  }
+  return [paramArray, input]
+}
+
+const getLengthOf = params => params.map(p => isUndefined(p.name) ? p.raw + ' ' : p.name + ' ').join().length
+
+const fnDeclParser = input => parser.bind(
+  parser.bind(
+    parser.bind(
+      nonReservedIdParser,
+      val => input => maybe(
+        funcParamsParser(input),
+        (params, rest) => {
+          let lengthOfParams = getLengthOf(params)
+          return returnRest(estemplate.funcDeclaration(val, params), input, rest.str, {name: 'column', value: lengthOfParams})
+        }
+      )
+    ),
+    val => input => maybe(
+        equalSignParser(input),
+        (v, rest) => [val, rest]
+      )
+  ),
+  val => input => maybe(
+    valueParser(input),
+      (body, rest) => {
+        val.declarations[0].init.body = body.type === 'ExpressionStatement' ? body.expression : body
+        return returnRest(val, input, rest.str)
       }
     )
-)
+)(input)
 
-const ifExprParser = input => mayBe(
-  parser.all(
-    ifParser, valueParser,
-    mayBeNewLineAndIndent, thenParser, valueParser,
-    mayBeNewLineAndIndent, elseParser, valueParser)(input),
-    (val, rest) => {
-      let [, condition, , , consequent, , , alternate] = val
-      return returnRest(estemplate.ifthenelse(condition, consequent, alternate), input, rest.str)
-    }
-)
-
-const statementParser = input => parser.any(multiLineCommentParser, singleLineCommentParser, returnParser, doBlockParser, ioParser, doFuncParser, declParser, ifExprParser, fnDeclParser, fnCallParser, lambdaParser, lambdaCallParser, spaceParser)(input)
+const statementParser = input => parser.any(multiLineCommentParser, singleLineCommentParser,
+                                            returnParser, doBlockParser, ioParser,
+                                            doFuncParser, declParser, ifExprParser,
+                                            fnDeclParser, fnCallParser, lambdaParser,
+                                            lambdaCallParser, spaceParser)(input)
 
 const programParser = (input, ast = estemplate.ast()) => {
   let [, rest] = returnRest('', input, input.str)
   let result = statementParser(rest)
-  if (result === null) {
+  if (isNull(result)) {
     if (input.str === '') return updateAst(ast)
     return new SyntaxError(`\n\n${input.str}\n ...at line: ${input.line}`)
   }
   if (typeof result[0] !== 'string') ast.body.push(result[0])
   return programParser(result[1], ast)
 }
-
-const keyParser = input => parser.any(identifierParser, stringParser, numberParser)(input)
-
-const arrayElemParser = input => mayBe(
-  parser.all(mayBeNewLineAndIndent, valueParser, mayBeSpace)(input),
-  (val, rest) => {
-    let [ , value, , ] = val
-    return [value, rest]
-  }
-)
-
-const commaCheck = (input, propArr) => {
-  let [, rest] = mayBeSpace(input)
-  let comma = commaParser(rest)
-  if (comma !== null) {
-    propArr.push(null)
-    let [, rest] = comma
-    return arrayElemsParser(rest, propArr)
-  }
-  return [propArr, rest]
-}
-
-const arrayElemsParser = (input, propArr = []) => {
-  let result = arrayElemParser(input)
-  if (result === null) return commaCheck(input, propArr)
-
-  let [val, rest] = result
-  propArr.push(val)
-
-  let comma = commaParser(rest)
-  if (comma === null) return [propArr, rest]
-  let [, _rest] = comma
-  return arrayElemsParser(_rest, propArr)
-}
-
-const arrayParser = input => {
-  let openSquareBracket, closeSquareBracket
-  if (!(openSquareBracket = openSquareBracketParser(input))) return null
-  let [, rest] = openSquareBracket
-  let result = arrayElemsParser(rest)
-  if (result === null) return null
-  let [arrayPropAst, arrayPropsRest] = result
-  if (!(closeSquareBracket = parser.all(mayBeNewLineAndIndent, closeSquareBracketParser)(arrayPropsRest))) return null
-  rest = closeSquareBracket[1]
-  return [estemplate.array(arrayPropAst), rest]
-}
-
-const objectParser = input => {
-  let openCurlyResult, closeCurlyResult
-  if (!(openCurlyResult = openCurlyBraceParser(input))) return null
-  let [, rest] = openCurlyResult
-  let result = objectPropsParser(rest)
-  if (result === null) return null
-  let [objPropArray, objPropsRest] = result
-  objPropsRest = mayBeSpace(objPropsRest)
-  if (!(closeCurlyResult = parser.all(mayBeNewLineAndIndent, closeCurlyBraceParser)(objPropsRest[1]))) return null
-  rest = closeCurlyResult[1]
-  return [estemplate.object(objPropArray), rest]
-}
-
-const objectPropParser = input => mayBe(
-  parser.all(mayBeNewLineAndIndent, keyParser, mayBeSpace, colonParser,
-             mayBeSpace, valueParser, mayBeSpace)(input),
-    (val, rest) => {
-      let [ , key, , , , value, , ] = val
-      return [estemplate.objectProperty(key, value), rest]
-    }
-)
-
-const objectPropsParser = (input, propArr = []) => {
-  let result = objectPropParser(input)
-  let commaResult
-  if (result === null) return [propArr, input]
-  let [val, rest] = result
-  propArr.push(val)
-  if (!(commaResult = commaParser(rest))) return [propArr, rest]
-  rest = commaResult[1]
-  if (closeCurlyBraceParser(rest)) return null
-  return objectPropsParser(rest, propArr)
-}
-
 /*  Module Exports programParser  */
 module.exports = programParser

--- a/lib/parserObject.js
+++ b/lib/parserObject.js
@@ -1,7 +1,7 @@
 const utils = require('./utilityFunctions')
 /* Utility Functions */
 const {
-  mayBe,
+  maybe,
   returnRest
 } = utils
 
@@ -15,12 +15,12 @@ const {
 
 const parser = {}
 
-parser.regex = regex => src => mayBe(
+parser.regex = regex => src => maybe(
   regex.exec(src.str),
   (m, val, rest) => returnRest(val, src, rest, {'name': 'column', 'value': val.length})
 )
 
-parser.bind = (mv, mf) => input => mayBe(
+parser.bind = (mv, mf) => input => maybe(
   mv(input),
   (val, rest) => mf(val)(rest)
 )
@@ -37,9 +37,9 @@ parser.all = (...parsers) => src => {
   return [values, rest]
 }
 
-parser.any = (...parsers) => src => {
+parser.any = (...parsers) => (...src) => {
   for (let parser of parsers) {
-    let result = parser(src)
+    let result = parser(...src)
     if (result !== null) return result
   }
   return null

--- a/lib/utilityFunctions.js
+++ b/lib/utilityFunctions.js
@@ -38,6 +38,13 @@ const isEmptyObj = obj => {
   return true
 }
 
+const isEmptyArr = arr => arr.toString() === ''
+
+const isNull = (...vals) => vals.reduce((acc, v1, v2) => ((v1 === null) && acc), true)
+const isUndefined = (...vals) => !notUndefined(...vals)
+
+const notNull = (...vals) => !isNull(...vals)
+const notUndefined = (...vals) => vals.reduce((acc, v1, v2) => ((v1 !== undefined) && acc), true)
 /* Functions for the  binary expression parser */
 const precedence = operator => opSpec[operator].prec
 const associativity = operator => opSpec[operator].assoc
@@ -50,6 +57,11 @@ module.exports = {
   unescape,
   returnRest,
   isEmptyObj,
+  isEmptyArr,
+  isNull,
+  isUndefined,
+  notNull,
+  notUndefined,
   precedence,
   associativity
 }

--- a/lib/utilityFunctions.js
+++ b/lib/utilityFunctions.js
@@ -2,7 +2,7 @@ const {ioFuncs, ioMeths} = require('./ioMethods')
 const languageConstruct = require('./languageConstructs')
 const opSpec = require('./operatorPrecedence')
 /*  Utility functions  */
-const mayBe = (value, func) => value === null ? null : func(...value)
+const maybe = (value, func) => value === null ? null : func(...value)
 const isLanguageConstruct = id => languageConstruct[id]
 const isIOFunc = id => ioFuncs[id]
 const isIOMethod = id => ioMeths[id]
@@ -50,7 +50,7 @@ const precedence = operator => opSpec[operator].prec
 const associativity = operator => opSpec[operator].assoc
 
 module.exports = {
-  mayBe,
+  maybe,
   isLanguageConstruct,
   isIOFunc,
   isIOMethod,


### PR DESCRIPTION
[in lib/utilityFunctions.js]
 - Rename `mayBe` to `maybe`
 - Add `isNull`, `notNull`, `isUndefined`, `notUndefined` to utility

[in lib/basicParsers.js]
 - Change regex declarations into functions which return regex

[in lib/parser.js]
 - Change order of declaration of parsers [Improves readability]
 - Split `getIOBody` into separate functions and rename it to
   `ioBodyParser`
 - Remove `.expression` from unnecessary places
 - Remove redundant code and make them into function declarations
 - Remove common code in `if...else...` blocks and put them outside

[in lib/parserObject.js]
 - `parser.any` now takes multiple arguments