### PR TITLE
Add support for `defineProp` outside `do` blocks

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -402,7 +402,7 @@ estemplate.ioStmt = (id, parentIO, args, ioParams) => ({
   'nextParams': ioParams
 })
 
-estemplate.defineProp = (objID, key, val) => ({
+estemplate.defineProp = (objID, key, val, mutable) => ({
   'type': 'ExpressionStatement',
   'expression': {
     'type': 'CallExpression',
@@ -461,8 +461,8 @@ estemplate.defineProp = (objID, key, val) => ({
             'computed': false,
             'value': {
               'type': 'Literal',
-              'value': false,
-              'raw': 'false'
+              'value': mutable,
+              'raw': mutable.toString()
             },
             'kind': 'init',
             'method': false,
@@ -477,8 +477,8 @@ estemplate.defineProp = (objID, key, val) => ({
             'computed': false,
             'value': {
               'type': 'Literal',
-              'value': true,
-              'raw': 'true'
+              'value': mutable,
+              'raw': mutable.toString()
             },
             'kind': 'init',
             'method': false,

--- a/lib/languageConstructs.js
+++ b/lib/languageConstructs.js
@@ -16,7 +16,8 @@ const languageConstructs = {
   'do': true,
   'console': true,
   'return': true,
-  'delete': true
+  'delete': true,
+  'defineProp': true
 }
 
 module.exports = languageConstructs

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -307,6 +307,17 @@ const memberExprParser = input => {
   return memExpr.type === 'MemberExpression' ? returnRest(memExpr, input, _rest.str) : null
 }
 
+const defineStmtParser = input => maybe(
+  parser.all(definePropParser, spaceParser,
+             parser.any(memberExprParser, nonReservedIdParser), spaceParser,
+             stringParser, spaceParser, valueParser)(input),
+  (val, rest) => {
+    let [, , objID, , key, , value] = val
+    let definePropStmt = estemplate.defineProp(objID, key, value, false)
+    return returnRest(definePropStmt, input, rest.str)
+  }
+)
+
 /* IO parsers */
 
 const ioFuncName = input => parser.all(ioFuncNameParser, spaceParser, argsParser)(input)
@@ -477,7 +488,7 @@ const maybeDefineStmt = (input, parentObj, bindBody) => maybe(
              stringParser, spaceParser, valueParser)(input),
   (val, rest) => {
     let [, , objID, , key, , value] = val
-    let definePropTmpl = estemplate.defineProp(objID, key, value)
+    let definePropTmpl = estemplate.defineProp(objID, key, value, true)
     return makeMap(definePropTmpl, rest, parentObj, bindBody)
   }
 )
@@ -654,7 +665,7 @@ const fnDeclParser = input => maybe(
 const statementParser = input => parser.any(multiLineCommentParser, singleLineCommentParser,
                                             returnParser, doBlockParser, ioParser,
                                             doFuncParser, declParser, ifExprParser,
-                                            fnDeclParser, fnCallParser, lambdaParser,
+                                            fnDeclParser, defineStmtParser, fnCallParser, lambdaParser,
                                             lambdaCallParser, spaceParser)(input)
 
 const programParser = (input, ast = estemplate.ast()) => {


### PR DESCRIPTION
[in lib/estemplate.js]
 - modify `estemplate.defineProp` to take `mutable` attribute

[in lib/parser.js]
 - add `defineStmtParser`

[in lib/languageConstructs.js]
 - add `defineProp` to `languageConstructs`