### PR TITLE
Remove `returnRest` to fix proper line numbers

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -8,12 +8,11 @@ const parserObj = require('./parserObject')
 const base = require('./basicParsers')
 const utils = require('./utilityFunctions')
 
-const {parser, lastParsed} = parserObj
+const {parser, unParsed} = parserObj
 
 /* Utility Functions */
 const {
   maybe,
-  returnRest,
   isEmptyObj,
   isEmptyArr,
   isNull,
@@ -55,7 +54,7 @@ const formBinaryExpr = (opStack, operandStack, input, rest) => {
   let opStackTop = opStack[opStack.length - 1]
   if (opStackTop === '$') {
     let binExpr = operandStack.pop()
-    return binExpr.type === 'BinaryExpression' ? returnRest(binExpr, input, input.str) : null // return final expression
+    return binExpr.type === 'BinaryExpression' ? [binExpr, input] : null // return final expression
   }
   let [right, left, op] = [operandStack.pop(), operandStack.pop(), opStack.pop()]
   let expr = estemplate.binaryExpression(left, op, right)
@@ -104,7 +103,7 @@ const ifExprParser = input => maybe(
     maybeNewLineAndIndent, elseParser, valueParser)(input),
     (val, rest) => {
       let [, condition, , , consequent, , , alternate] = val
-      return returnRest(estemplate.ifthenelse(condition, consequent, alternate), input, rest.str)
+      return [estemplate.ifthenelse(condition, consequent, alternate), rest]
     }
 )
 
@@ -125,7 +124,7 @@ const letExpressionParser = input => maybe(
   (val, rest) => {
     let [, [letIdArray, letLiteralArray], , expr] = val
     let letExpr = estemplate.letExpression(letIdArray, letLiteralArray, expr)
-    return returnRest(letExpr, input, rest.str)
+    return [letExpr, rest]
   }
 )
 
@@ -141,7 +140,7 @@ const lambdaParser = input => maybe(
   parser.all(slashParser, paramsParser, thinArrowParser, valueParser)(input),
   (val, rest) => {
     let [, params, , expr] = val
-    return returnRest(estemplate.lambda(params, expr), input, rest.str)
+    return [estemplate.lambda(params, expr), rest]
   }
 )
 
@@ -163,7 +162,7 @@ const fnCallParser = input => maybe(
     let [callee, , args] = val
     let callExpr = estemplate.fnCall(callee, args)
     let expr = rest.str.startsWith('\n') ? estemplate.expression(callExpr) : callExpr
-    return returnRest(expr, input, rest.str)
+    return [expr, rest]
   }
 )
 
@@ -183,7 +182,7 @@ const lambdaCallParser = input => {
   let [[, lambdaAst, , argsArr], rest] = result
   let {params, body} = lambdaAst.expression
   let val = estemplate.lambdaCall(params, argsArr, body)
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 
 /* Parsers for structures */
@@ -276,7 +275,7 @@ const objectParser = input => {
 /* Helper functions for memberExprParser */
 const formMemberExpression = (input, obj) => {
   let prop = parser.any(dotParser, subscriptParser, identifierParser)(input)
-  if (isNull(prop)) return returnRest(obj, input, input.str)
+  if (isNull(prop)) return [obj, input]
   let [exp, rest] = prop
   if (exp.isSubscript) return formMemberExpression(rest, estemplate.subscriptExpression(obj, exp))
   exp.isSubscript = false
@@ -292,7 +291,7 @@ const subscriptParser = input => {
   if (notNull(result)) {
     let [[, prop], rest] = result
     prop.isSubscript = true
-    return returnRest(prop, input, rest.str)
+    return [prop, rest]
   }
   return null
 }
@@ -304,7 +303,7 @@ const memberExprParser = input => {
   let result = formMemberExpression(rest, obj)
   let [memExpr, _rest] = result
   memExpr = memExpr.type === 'ExpressionStatement' ? memExpr.expression : memExpr
-  return memExpr.type === 'MemberExpression' ? returnRest(memExpr, input, _rest.str) : null
+  return memExpr.type === 'MemberExpression' ? [memExpr, _rest] : null
 }
 
 const defineStmtParser = input => maybe(
@@ -314,7 +313,7 @@ const defineStmtParser = input => maybe(
   (val, rest) => {
     let [, , objID, , key, , value] = val
     let definePropStmt = estemplate.defineProp(objID, key, value, false)
-    return returnRest(definePropStmt, input, rest.str)
+    return [definePropStmt, rest]
   }
 )
 
@@ -326,7 +325,7 @@ const doBlockParser = input => {
   let result = parser.all(doParser, ioBodyParser)(input)
   if (isNull(result)) return null
   let [[, doBlock], rest] = result
-  return returnRest(estemplate.expression(doBlock), input, rest.str)
+  return [estemplate.expression(doBlock), rest]
 }
 
 const doFuncParser = input => {
@@ -335,7 +334,7 @@ const doFuncParser = input => {
   let [[funcId, params, , funcBody], rest] = result
   let val = estemplate.funcDeclaration(funcId, params, funcBody)
   val.sType = 'IO'
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 
 const ioStmtParser = (input, parentObj) => {
@@ -345,10 +344,10 @@ const ioStmtParser = (input, parentObj) => {
   if (isEmptyObj(parentObj)) {
     let val = estemplate.ioCall(id, args)
     val.sType = 'IO'
-    return returnRest(val, input, rest.str)
+    return [val, rest]
   }
   let val = estemplate.ioStmt(id, parentObj, args, parentObj.nextParams)
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 
 const noArgsCallParser = input => {
@@ -358,7 +357,7 @@ const noArgsCallParser = input => {
                           spaceParser, openParensParser, closeParensParser)(input)
   if (isNull(result)) return null
   let [[callee], rest] = result
-  return returnRest(estemplate.fnCall(callee, []), input, rest.str)
+  return [estemplate.fnCall(callee, []), rest]
 }
 
 /* Helper functions for bindStatementParser */
@@ -447,7 +446,7 @@ const handlerParser = input => {
                           closeParensParser)(input)
   if (isNull(result)) return null
   let [[, val], rest] = result
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 
 const maybeStmtParser = (input, parentObj, bindBody) => maybe(
@@ -517,7 +516,7 @@ const makeFinalStmt = (input, rest, parentObj, bindBody) => {
   if (isEmptyObj(parentObj) && bindBody.length !== 0) {
     parentObj = getCbBody(bindBody.slice(1), bindBody[0])
     let val = estemplate.defaultIOThen(parentObj)
-    return returnRest(val, input, rest.str)
+    return [val, rest]
   }
 
   let cbParams = isUndefined(parentObj.nextParams) ? [] : parentObj.nextParams
@@ -531,7 +530,7 @@ const makeFinalStmt = (input, rest, parentObj, bindBody) => {
     val = estemplate.lambda([], estemplate.ioMap(parentObj, callBack, cbParams)).expression // need .expression here
   }
   val.sType = 'IO'
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 /* final statement ends here */
 
@@ -598,7 +597,7 @@ const ioDecl = (maybeDo, doID, input, rest) => {
   }
   ioBody.sType = 'IO'
   let val = estemplate.declaration(doID, ioBody)
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 
 const ioParser = input => {
@@ -615,7 +614,7 @@ const ioParser = input => {
   if (funcNotMain) {
     let val = maybeDo
     val.sType = 'IO'
-    return returnRest(estemplate.declaration(doID, val), input, rest.str)
+    return [estemplate.declaration(doID, val), rest]
   }
   return ioDecl(maybeDo, doID, input, rest)
 }
@@ -631,7 +630,7 @@ const parenthesesParser = input => {
                           valueParser, maybeNewLineAndIndent, closeParensParser)(input)
   if (isNull(result)) return null
   let [[, , val], rest] = result
-  return returnRest(val, input, rest.str)
+  return [val, rest]
 }
 
 const valueParser = input => parser.any(binaryExprParser, fnCallParser, expressionParser)(input)
@@ -640,7 +639,7 @@ const declParser = input => maybe(
   parser.all(nonReservedIdParser, equalSignParser, valueParser)(input),
   (val, rest) => {
     let [id, , value] = val
-    return returnRest(estemplate.declaration(id, value), input, rest.str)
+    return [estemplate.declaration(id, value), rest]
   }
 )
 
@@ -658,7 +657,7 @@ const fnDeclParser = input => maybe(
   parser.all(nonReservedIdParser, funcParamsParser, equalSignParser, valueParser)(input),
   (val, rest) => {
     let [funcID, paramsArr, , body] = val
-    return returnRest(estemplate.funcDeclaration(funcID, paramsArr, body), input, rest.str)
+    return [estemplate.funcDeclaration(funcID, paramsArr, body), rest]
   }
 )
 
@@ -669,11 +668,11 @@ const statementParser = input => parser.any(multiLineCommentParser, singleLineCo
                                             lambdaCallParser, spaceParser)(input)
 
 const programParser = (input, ast = estemplate.ast()) => {
-  let [, rest] = returnRest('', input, input.str)
+  let [, rest] = ['', input]
   let result = statementParser(rest)
   if (isNull(result)) {
     if (input.str === '') return updateAst(ast)
-    return new SyntaxError(`\n\n${lastParsed.str}\n ...at line: ${lastParsed.line} column: ${lastParsed.column}`)
+    return new SyntaxError(`\n\n${unParsed.str}\n\n ...at line: ${unParsed.line} column: ${unParsed.column}`)
   }
   if (typeof result[0] !== 'string') ast.body.push(result[0])
   return programParser(result[1], ast)

--- a/lib/parserObject.js
+++ b/lib/parserObject.js
@@ -16,18 +16,18 @@ const {
 
 const parser = {}
 
-const lastParsed = {line: 1, column: 0}
+const unParsed = {line: 1, column: 0}
 
 const updateParsed = val => {
-  let maxLine = lastParsed.line < val.line // if existing parsed line is less than newly parsed line
-  let maxColumn = lastParsed.line === val.line && lastParsed.column < val.column // if lines match then compare column
+  let maxLine = unParsed.line < val.line // if existing parsed line is less than newly parsed line
+  let maxColumn = unParsed.line === val.line && unParsed.column < val.column // if lines match then compare column
+  let currentExpr = val.str.split('\n')[0]
   if (maxLine) {
-    let currentExpr = val.str.split('\n')[0];
-    [lastParsed.str, lastParsed.line, lastParsed.column] = [currentExpr, val.line, val.column]
+    [unParsed.str, unParsed.line, unParsed.column] = [currentExpr, val.line, val.column]
   }
   if (maxColumn) {
-    if (isUndefined(lastParsed.str)) lastParsed.str = val.str
-    lastParsed.column = val.column
+    if (isUndefined(unParsed.str)) unParsed.str = currentExpr
+    unParsed.column = val.column
   }
 }
 
@@ -66,4 +66,4 @@ parser.any = (...parsers) => (...src) => {
 }
 
 /* Module exports the parser object along with all its methods */
-module.exports = {parser, lastParsed}
+module.exports = {parser, unParsed}


### PR DESCRIPTION
[in lib/parser.js]
 - Remove `returnRest` which solves the issue of proper line numbers
 - Change `lastParsed` to `unParsed` to reflect actual usage

[in lib/parserObject.js]
 - Rename `lastParsed` to `unParsed` for better understanding of its
   working
 - Add only single unparsed line to `unParsed` object