### PR TITLE
Use `parser.regex` which handles line numbers

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -54,6 +54,10 @@ const libNameRegex = () => /^(node-core|browser-core)((.|\n)*)$/
 /*
   All required parsers are created below
 */
+const idParser = input => parser.regex(idRegex)(input)
+
+const numParser = input => parser.regex(numRegex)(input)
+
 const spaceParser = input => parser.regex(spaceRegex)(input)
 
 const equalSignParser = input => parser.regex(equalSignRegex)(input)
@@ -88,91 +92,90 @@ const returnParser = input => maybe(
 )
 
 const numberParser = input => maybe(
-  numRegex().exec(input.str),
-  (m, num, rest) => returnRest(estemplate.literal(num, num), input, rest, {'name': 'column', 'value': num.length})
+  numParser(input),
+  (num, rest) => [estemplate.literal(num), rest]
 )
 
 const nonReservedIdParser = input => maybe(
-  idRegex().exec(input.str),
-  (m, name, rest) => (isLanguageConstruct(name) || isIOFunc(name) || isIOMethod(name)) ? null
-    : returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
+  idParser(input),
+  (name, rest) => (isLanguageConstruct(name) || isIOFunc(name) || isIOMethod(name)) ? null
+    : [estemplate.identifier(name), rest]
 )
 
 const identifierParser = input => maybe(
-  idRegex().exec(input.str),
-  (m, name, rest) => returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length})
+  idParser(input),
+  (name, rest) => [estemplate.identifier(name), rest]
 )
 
 const ioFuncNameParser = input => maybe(
-  idRegex().exec(input.str),
-  (m, name, rest) => isIOFunc(name) ? returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}) : null
+  idParser(input),
+  (name, rest) => isIOFunc(name) ? [estemplate.identifier(name), rest] : null
 )
 
 const ioMethodNameParser = input => maybe(
-  idRegex().exec(input.str),
-  (m, name, rest) => isIOMethod(name) ? returnRest(estemplate.identifier(name), input, rest, {'name': 'column', 'value': name.length}) : null
+  idParser(input),
+  (name, rest) => isIOMethod(name) ? [estemplate.identifier(name), rest] : null
 )
 
 const nullParser = input => maybe(
-  nullRegex().exec(input.str),
-  (m, val, rest) => returnRest(estemplate.nullLiteral(val), input, rest, {'name': 'column', 'value': 4})
+  parser.regex(nullRegex)(input),
+  (val, rest) => [estemplate.nullLiteral(val), rest]
 )
 
 const stringParser = input => maybe(
-  stringRegex().exec(input.str),
-  (m, string, rest) => returnRest(estemplate.stringLiteral(unescape(string)),
-                                  input, rest, {'name': 'column', 'value': string.length})
+  parser.regex(stringRegex)(input),
+  (string, rest) => [estemplate.stringLiteral(unescape(string)), rest]
 )
 
 const booleanParser = input => maybe(
-  boolRegex().exec(input.str),
-  (m, bool, rest) => returnRest(estemplate.boolLiteral(bool), input, rest, {'name': 'column', 'value': bool.length})
+  parser.regex(boolRegex)(input),
+  (bool, rest) => [estemplate.boolLiteral(bool), rest]
 )
 
 const regexParser = input => maybe(
-  regexRegex().exec(input.str),
+  regexRegex.exec(input.str),
   (m, regex, pattern, b, flags, rest) => returnRest(estemplate.regex(regex, pattern, flags), input, rest,
                                                     {'name': 'column', 'value': pattern.length})
 )
 
 const openParensParser = input => maybe(
-  openParensRegex().exec(input.str),
-  (m, openParens, rest) => returnRest(openParens, input, rest, {'name': 'column', 'value': 1})
+  parser.regex(openParensRegex)(input),
+  (openParens, rest) => [openParens, rest]
 )
 
 const closeParensParser = input => maybe(
-  closeParensRegex().exec(input.str),
-  (m, closeParens, rest) => returnRest(closeParens, input, rest, {'name': 'column', 'value': 1})
+  parser.regex(closeParensRegex)(input),
+  (closeParens, rest) => [closeParens, rest]
 )
 
 const openCurlyBraceParser = input => maybe(
-  openCurlyRegex().exec(input.str),
-  (m, openCurlyBrace, rest) => returnRest(openCurlyBrace, input, rest, {'name': 'column', 'value': openCurlyBrace.length})
+  parser.regex(openCurlyRegex)(input),
+  (openCurlyBrace, rest) => [openCurlyBrace, rest]
 )
 
 const closeCurlyBraceParser = input => maybe(
-  closeCurlyRegex().exec(input.str),
-  (m, closeCurlyBrace, rest) => returnRest(closeCurlyBrace, input, rest, {'name': 'column', 'value': closeCurlyBrace.length})
+  parser.regex(closeCurlyRegex)(input),
+  (closeCurlyBrace, rest) => [closeCurlyBrace, rest]
 )
 
 const openSquareBracketParser = input => maybe(
-  openSquareBracketRegex().exec(input.str),
-  (m, openSquareBracket, rest) => returnRest(openSquareBracket, input, rest, {'name': 'column', 'value': openSquareBracket.length})
+  parser.regex(openSquareBracketRegex)(input),
+  (openSquareBracket, rest) => [openSquareBracket, rest]
 )
 
 const closeSquareBracketParser = input => maybe(
-  closeSquareBracketRegex().exec(input.str),
-  (m, closeSquareBracket, rest) => returnRest(closeSquareBracket, input, rest, {'name': 'column', 'value': closeSquareBracket.length})
+  parser.regex(closeSquareBracketRegex)(input),
+  (closeSquareBracket, rest) => [closeSquareBracket, rest]
 )
 
 const commaParser = input => maybe(
-  commaRegex().exec(input.str),
-  (m, comma, rest) => returnRest(comma, input, rest, {'name': 'column', 'value': comma.length})
+  parser.regex(commaRegex)(input),
+  (comma, rest) => [comma, rest]
 )
 
 const colonParser = input => maybe(
-  colonRegex().exec(input.str),
-  (m, colon, rest) => returnRest(colon, input, rest, {'name': 'column', 'value': colon.length})
+  parser.regex(colonRegex)(input),
+  (colon, rest) => [colon, rest]
 )
 
 const singleLineCommentParser = input => maybe(


### PR DESCRIPTION
- Remove use of `returnRest` in parsers which now use `parser.regex`
  because `parser.regex` handles line numbers on its own