### PR TITLE
Reduce maps and maybe<Val> statements

### DIFF
--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -359,18 +359,6 @@ estemplate.ioMap = (parentIO, pureFunc, nextParams = []) => ({
   nextParams
 })
 
-estemplate.ioMayBe = (parentIO, methodName, args, nextParams = []) => ({
-  'type': 'CallExpression',
-  'callee': {
-    'type': 'MemberExpression',
-    'computed': false,
-    'object': parentIO,
-    'property': methodName
-  },
-  'arguments': args.map(extractExpr),
-  nextParams
-})
-
 estemplate.ioThen = (parentIO, func, ioParams) => ({
   'type': 'CallExpression',
   'callee': {
@@ -386,40 +374,18 @@ estemplate.ioThen = (parentIO, func, ioParams) => ({
   ioParams
 })
 
-estemplate.ioStmt = (id, parentIO, args, ioParams) => ({
+estemplate.ioFunc = (id, args) => ({
   'type': 'CallExpression',
   'callee': {
     'type': 'MemberExpression',
     'computed': false,
-    'object': parentIO,
-    'property': {
+    'object': {
       'type': 'Identifier',
-      'name': 'bind'
-    }
+      'name': 'IO'
+    },
+    'property': id
   },
-  'arguments': [
-    {
-      'type': 'ArrowFunctionExpression',
-      'id': null,
-      'params': ioParams,
-      'body': {
-        'type': 'CallExpression',
-        'callee': {
-          'type': 'MemberExpression',
-          'computed': false,
-          'object': {
-            'type': 'Identifier',
-            'name': 'IO'
-          },
-          'property': id
-        },
-        'arguments': args.map(extractExpr)
-      },
-      'generator': false,
-      'expression': false
-    }
-  ],
-  'nextParams': ioParams
+  'arguments': args.map(extractExpr)
 })
 
 estemplate.defineProp = (objID, key, val, mutable) => ({
@@ -512,10 +478,7 @@ estemplate.defineProp = (objID, key, val, mutable) => ({
 
 estemplate.returnStmt = (args) => ({
   'type': 'ReturnStatement',
-  'argument': {
-    'type': 'ArrayExpression',
-    'elements': args.map(extractExpr)
-  }
+  'argument': args
 })
 
 estemplate.defaultIOThen = parentObj => ({

--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -279,6 +279,19 @@ estemplate.ifthenelse = (condition, result1, result2) => ({
   }
 })
 
+estemplate.ifStmt = (predicate, consequent) => ({
+  'type': 'IfStatement',
+  'test': predicate,
+  'consequent': {
+    'type': 'BlockStatement',
+    'body': [
+      consequent,
+      estemplate.returnStmt(null)
+    ]
+  },
+  'alternate': null
+})
+
 estemplate.array = elements => ({'type': 'ArrayExpression', 'elements': elements.map(extractExpr)})
 
 estemplate.object = value => ({

--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -241,7 +241,7 @@ estemplate.lambda = (params, body) => ({
 })
 
 estemplate.binaryExpression = (left, op, right) => {
-  let opType = types[op].type
+  let opType = op === 'instanceof' ? 'any' : types[op].type
   if (op === '^') return binaryExpr(left, '**', right, opType)
   if (op === '++') return binaryExpr(left, '+', right, opType)
   if (op === '==') return binaryExpr(left, '===', right, opType)

--- a/lib/estemplate.js
+++ b/lib/estemplate.js
@@ -316,7 +316,7 @@ estemplate.ioCall = (ioFunc, args, nextParams = []) => ({
   nextParams
 })
 
-estemplate.ioBind = (parentIO, ioCall, nextParams = []) => estemplate.ioMap({
+estemplate.ioBind = (parentIO, ioCall, nextParams = []) => ({
   'type': 'CallExpression',
   'callee': {
     'type': 'MemberExpression',
@@ -329,7 +329,7 @@ estemplate.ioBind = (parentIO, ioCall, nextParams = []) => estemplate.ioMap({
   },
   'arguments': [ioCall].map(extractExpr),
   nextParams
-}, estemplate.lambda(nextParams, estemplate.array(nextParams)), nextParams)
+})
 
 estemplate.ioMap = (parentIO, pureFunc, nextParams = []) => ({
   'type': 'CallExpression',

--- a/lib/include/core.js
+++ b/lib/include/core.js
@@ -1,6 +1,11 @@
+const notAllDefined = args => args === undefined || args.filter(arg => arg === undefined).length > 0;
+
 class IOCore {
   constructor (ioFunc) {
-    this.then = cb => ioFunc((...args) => { cb(...args) });
+    this.then = cb => ioFunc((...args) => {
+      if (notAllDefined(args)) return;
+      cb(...args)
+    });
   };
 
   reject (pred) {
@@ -99,6 +104,7 @@ class IOCore {
     let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
+        if (notAllDefined(args)) return;
         let result = transform(...args);
         if (Array.isArray(result)) {
           cb(...result);
@@ -114,6 +120,7 @@ class IOCore {
     let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
+        if (notAllDefined(args)) return;
         let io = ioFunc(...args);
         io.then((...ioargs) => cb(...args, ...ioargs));
       });

--- a/lib/include/core.js
+++ b/lib/include/core.js
@@ -3,107 +3,17 @@ class IOCore {
     this.then = cb => ioFunc((...args) => cb(...args));
   };
 
-  reject (pred) {
-    let saveThen = this.then;
-    this.then = cb => {
-      saveThen((...args) => {
-        let result = pred(...args);
-        if (result !== null) {
-          if (Array.isArray(result)) {
-            cb(...result);
-          } else {
-            cb(result);
-          }
-        };
-      });
-    };
-    return this;
-  };
-
-  maybeFalse (mv, handler) {
-    let saveThen = this.then;
-    this.then = cb => {
-      saveThen((...args) => {
-        let result = mv(...args);
-        if (result === false) {
-          handler(...args);
-        } else {
-          cb(...args);
-        }
-      });
-    };
-    return this;
-  };
-
-  maybeNull (mv, handler) {
-    let saveThen = this.then;
-    this.then = cb => {
-      saveThen((...args) => {
-        let result = mv(...args);
-        if (result === null) {
-          handler(...args);
-        } else {
-          cb(...args);
-        }
-      });
-    };
-    return this;
-  };
-
-  maybeErr (mv, handler) {
-    let saveThen = this.then;
-    this.then = cb => {
-      saveThen((...args) => {
-        let result = mv(...args);
-        if (result instanceof Error) {
-          handler(...args);
-        } else {
-          cb(...args);
-        }
-      });
-    };
-    return this;
-  };
-
-  maybeTrue (mv, handler) {
-    let saveThen = this.then;
-    this.then = cb => {
-      saveThen((...args) => {
-        let result = mv(...args);
-        if (result === true) {
-          handler(...args);
-        } else {
-          cb(...args);
-        }
-      });
-    };
-    return this;
-  };
-
-  maybeUndefined (mv, handler) {
-    let saveThen = this.then;
-    this.then = cb => {
-      saveThen((...args) => {
-        let result = mv(...args);
-        if (result === undefined) {
-          handler(...args);
-        } else {
-          cb(...args);
-        }
-      });
-    };
-    return this;
-  };
-
   map (transform) {
     let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
         let result = transform(...args);
-        if (Array.isArray(result)) {
-          cb(...result);
-        } else {
-          cb(result);
+        if (result !== undefined) {
+          if (Array.isArray(result)) {
+            cb(...result);
+          } else {
+            cb(result);
+          }
         }
       });
     };
@@ -114,9 +24,16 @@ class IOCore {
     let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        args = ioFunc.length < args.length ? args.slice(0, ioFunc.length) : args
-        let io = ioFunc(...args);
-        io.then((...ioargs) => cb(...args, ...ioargs));
+        if (args !== undefined) {
+          let _args = ioFunc.length < args.length ? args.slice(0, ioFunc.length) : args;
+          let cbReturn = ioFunc(..._args);
+          if (cbReturn !== undefined) {
+            let cbReturnLen = cbReturn.length;
+            let io = cbReturn[cbReturnLen - 1];
+            let argsForCb = cbReturn.slice(0, cbReturnLen - 1);
+            io.then((...ioargs) => cb(...argsForCb, ...ioargs));
+          }
+        }
       });
     };
     return this;

--- a/lib/include/core.js
+++ b/lib/include/core.js
@@ -1,11 +1,6 @@
-const notAllDefined = args => args === undefined || args.filter(arg => arg === undefined).length > 0;
-
 class IOCore {
   constructor (ioFunc) {
-    this.then = cb => ioFunc((...args) => {
-      if (notAllDefined(args)) return;
-      cb(...args)
-    });
+    this.then = cb => ioFunc((...args) => cb(...args));
   };
 
   reject (pred) {
@@ -104,7 +99,6 @@ class IOCore {
     let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        if (notAllDefined(args)) return;
         let result = transform(...args);
         if (Array.isArray(result)) {
           cb(...result);

--- a/lib/include/core.js
+++ b/lib/include/core.js
@@ -120,7 +120,7 @@ class IOCore {
     let saveThen = this.then;
     this.then = cb => {
       saveThen((...args) => {
-        if (notAllDefined(args)) return;
+        args = ioFunc.length < args.length ? args.slice(0, ioFunc.length) : args
         let io = ioFunc(...args);
         io.then((...ioargs) => cb(...args, ...ioargs));
       });

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -383,11 +383,6 @@ const maybeDOMStmt = input => maybe(
 
 const maybeBindStmt = input => (parser.all(bindIDParser, reverseBindParser, parser.any(fnCallParser, maybeDOMStmt, ioFuncName, nonReservedIdParser))(input))
 
-const mapIOCall = (ioFunc, args, nextParams) => estemplate.ioMap(estemplate.ioCall(ioFunc, args, nextParams),
-                                                                 estemplate.lambda(nextParams,
-                                                                                   estemplate.array(nextParams)),
-                                                                 nextParams)
-
 const isIOorFuncCall = maybeIOFunc => {
   let isFuncCall = notUndefined(maybeIOFunc.type, maybeIOFunc.expression) && maybeIOFunc.expression.type === 'CallExpression'
   let isIOCall = notUndefined(maybeIOFunc.type) && maybeIOFunc.type === 'Identifier'
@@ -433,7 +428,7 @@ const bindStmt = (maybeBind, parentObj, bindBody, mapBody) => {
   if (isNewIO) args = createIOBody(args, ioFunc)
 
   if (isEmptyObj(parentObj)) {
-    let val = isIOorFunc ? maybeIOFunc : mapIOCall(ioFunc, args, nextParams)
+    let val = isIOorFunc ? maybeIOFunc : estemplate.ioCall(ioFunc, args, nextParams)
     if (isFuncCall) val = val.expression
     val.nextParams = isIOorFunc ? nextParams : val.nextParams
     return ioBodyParser(rest, val, bindBody, mapBody)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -351,8 +351,11 @@ const ioStmtParser = (input, parentObj, mapBody = {stmts: [], propagate: []}) =>
       val_.sType = 'IO'
       return [val_, rest]
     }
-    if (!isEmptyArr(mapBody.stmts)) parentObj = makeMap(parentObj, mapBody)
-    let val_ = estemplate.ioStmt(id, parentObj, args, parentObj.nextParams)
+    let ioFunc = estemplate.ioFunc(id, args)
+    let callBack = isEmptyArr(mapBody.stmts) ? estemplate.lambda(parentObj.nextParams, estemplate.array(parentObj.nextParams.concat(ioFunc)))
+        : estemplate.lambda(parentObj.nextParams, estemplate.blockStmt(mapBody.stmts.concat(estemplate.returnStmt(estemplate.array(parentObj.nextParams.concat(mapBody.propagate.concat(ioFunc)))))))
+    parentObj.nextParams = parentObj.nextParams.concat(mapBody.propagate)
+    let val_ = estemplate.ioBind(parentObj, callBack, parentObj.nextParams)
     return [val_, rest]
   }
 )
@@ -404,11 +407,12 @@ const makeBind = (isIOorFunc, isIOCall, maybeIOFunc, ioFunc, args, nextParams) =
 }
 
 const formBindStmt = (cbBody, parentObj, nextParams, rest, bindBody, mapBody) => {
-  let cbParams = parentObj.nextParams.concat(mapBody.propagate)
-  let callBack = estemplate.lambda(cbParams, cbBody)
-  return isEmptyArr(mapBody.stmts)
-    ? ioBodyParser(rest, estemplate.ioBind(parentObj, callBack, nextParams), bindBody, mapBody)
-    : ioBodyParser(rest, estemplate.ioBind(makeMap(parentObj, mapBody), callBack, nextParams), bindBody)
+  let cbParams = parentObj.nextParams
+  let callBack = isEmptyArr(mapBody.stmts) ? estemplate.lambda(cbParams, estemplate.array(cbParams.concat(cbBody)))
+      : estemplate.lambda(cbParams, estemplate.blockStmt(mapBody.stmts.concat(estemplate.returnStmt(estemplate.array(cbParams.concat(mapBody.propagate).concat(cbBody))))))
+  parentObj = estemplate.ioBind(parentObj, callBack, cbParams)
+  parentObj.nextParams = nextParams
+  return ioBodyParser(rest, parentObj, bindBody)
 }
 
 const bindStmt = (maybeBind, parentObj, bindBody, mapBody) => {
@@ -464,6 +468,25 @@ const maybeLetStmt = (input, parentObj, bindBody, mapBody) => maybe(
 /* letStmtParser ends here */
 
 /* maybe<Val> parser */
+const createIfStmt = (left, op, template, right) =>
+      consequent => estemplate.ifStmt(estemplate.binaryExpression(left, op, estemplate[template](right)), consequent)
+
+const getPredicate = (methodName, value) => {
+  let maybeVal = methodName.name.slice(5)
+  switch (maybeVal) {
+    case 'True':
+      return createIfStmt(value, '==', 'boolLiteral', 'true')
+    case 'False':
+      return createIfStmt(value, '==', 'boolLiteral', 'false')
+    case 'Undefined':
+      return createIfStmt(value, '==', 'identifier', 'undefined')
+    case 'Err':
+      return createIfStmt(value, 'instanceof', 'identifier', 'Error')
+    case 'Null':
+      return createIfStmt(value, '==', 'nullLiteral', 'null')
+  }
+}
+
 const handlerParser = input => maybe(
   parser.all(openParensParser,
              parser.any(fnCallParser, ioFuncName, lambdaCallParser),
@@ -481,25 +504,22 @@ const maybeStmtParser = (input, parentObj, bindBody, mapBody) => maybe(
 
 const maybeStmt = (maybeVal, rest, parentObj, bindBody, mapBody) => {
   let [methodName, , value, , handler] = maybeVal
-  if (!isEmptyArr(mapBody.stmts)) parentObj = makeMap(parentObj, mapBody)
-  let nextParams = parentObj.nextParams
   let handlerBody = handler
   if (Array.isArray(handler)) {
     let [ioFunc, , args] = handler
     handler = ioFunc
     handlerBody = estemplate.defaultIOThen(estemplate.ioCall(handler, args))
   }
-  let handler_ = estemplate.lambda(nextParams, handlerBody)
-  let maybeValue = estemplate.lambda(nextParams, value)
-  let val = estemplate.ioMayBe(parentObj, methodName, [maybeValue, handler_], nextParams)
-  return ioBodyParser(rest, val, bindBody)
+  let val = getPredicate(methodName, value)(handlerBody)
+  mapBody.stmts = mapBody.stmts.concat(val)
+  return ioBodyParser(rest, parentObj, bindBody, mapBody)
 }
 /* maybe<val> parser ends here */
 
 /* Handler function for delete and defineProp */
 const makeMap = (parentObj, mapBody) => {
   let nextParams = parentObj.nextParams
-  let returnVal = estemplate.returnStmt(nextParams.concat(mapBody.propagate))
+  let returnVal = estemplate.returnStmt(estemplate.array(nextParams.concat(mapBody.propagate)))
   let cbBody = estemplate.blockStmt(mapBody.stmts.concat(returnVal))
   let callBack = estemplate.lambda(nextParams, cbBody)
   let val = estemplate.ioMap(parentObj, callBack, nextParams)
@@ -537,11 +557,13 @@ const getCbBody = (bindBody, parentObj) => {
     if (parentObj.type === 'Identifier') return estemplate.fnCall(parentObj, [])
     return parentObj
   }
-  let callBack = estemplate.lambda(parentObj.nextParams, estemplate.fnCall(bindBody[0], []))
+  let callBack = estemplate.lambda(parentObj.nextParams, estemplate.array([estemplate.fnCall(bindBody[0], [])]))
   let val = estemplate.ioBind(parentObj, callBack, parentObj.nextParams)
   val.nextParams = parentObj.nextParams
   return getCbBody(bindBody.slice(1), val)
 }
+
+const makeBlock = (mapBody, cbBody) => estemplate.blockStmt(mapBody.stmts.concat(cbBody))
 
 const makeFinalStmt = (input, rest, parentObj, bindBody, mapBody) => {
   if (isEmptyObj(parentObj) && bindBody.length === 0) return null
@@ -550,15 +572,24 @@ const makeFinalStmt = (input, rest, parentObj, bindBody, mapBody) => {
     let val = estemplate.defaultIOThen(parentObj)
     return [val, rest]
   }
-  if (!isEmptyArr(mapBody.stmts)) parentObj = makeMap(parentObj, mapBody)
   let cbParams = isUndefined(parentObj.nextParams) ? [] : parentObj.nextParams
   parentObj = getCbBody(bindBody, parentObj)
-  let cbBody = isUndefined(parentObj.returnVals) ? estemplate.array(bindBody) : estemplate.array(parentObj.returnVals)
-  let callBack = estemplate.lambda(cbParams, cbBody)
+  let noReturnStmt = isUndefined(parentObj.returnVals)
+  let cbBody = noReturnStmt
+      ? isEmptyArr(bindBody) ? bindBody : estemplate.array(bindBody)
+      : estemplate.array(parentObj.returnVals)
+  let callBack = estemplate.lambda(cbParams, isEmptyArr(mapBody.stmts) ? cbBody : makeBlock(mapBody, cbBody))
+  if (isEmptyArr(mapBody.stmts) && isEmptyArr(cbBody)) {
+    callBack = estemplate.lambda([], estemplate.array([]))
+  }
   let val
   if (isUndefined(parentObj.returnVals)) {
     val = estemplate.ioThen(parentObj, callBack, cbParams)
   } else {
+    if (!isEmptyArr(mapBody.stmts) && !isEmptyArr(cbBody)) {
+      let cbExpr = callBack.type === 'ArrowFunctionExpression' ? callBack.callee : callBack.expression
+      cbExpr.body = makeBlock(mapBody, estemplate.returnStmt(cbBody))
+    }
     val = estemplate.lambda([], estemplate.ioMap(parentObj, callBack, cbParams)).expression // need .expression here
   }
   val.sType = 'IO'
@@ -574,9 +605,6 @@ const maybeFinalStmt = (finalStmt, input, parentObj, bindBody, mapBody) => {
   }
   [, rest] = result
   let maybeReturn = parser.all(returnKeywordParser, spaceParser, argsParser)(rest)
-  let mapIsNotEmpty = !isEmptyArr(mapBody.stmts)
-  parentObj = mapIsNotEmpty && notNull(maybeReturn) ? makeMap(parentObj, mapBody) : parentObj
-  mapBody = mapIsNotEmpty && notNull(maybeReturn) ? {stmts: [], propagate: []} : mapBody
   if (notNull(maybeReturn)) {
     [[, , parentObj.returnVals], rest] = maybeReturn
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cleanlang",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A Clean new programming Language",
   "main": "lib/clean.js",
   "bin": {

--- a/test/assert/allFeatures.json
+++ b/test/assert/allFeatures.json
@@ -487,355 +487,32 @@
                             "type": "MemberExpression",
                             "computed": false,
                             "object": {
-                              "type": "CallExpression",
-                              "callee": {
-                                "type": "MemberExpression",
-                                "computed": false,
-                                "object": {
-                                  "type": "CallExpression",
-                                  "callee": {
-                                    "type": "MemberExpression",
-                                    "computed": false,
-                                    "object": {
-                                      "type": "CallExpression",
-                                      "callee": {
-                                        "type": "MemberExpression",
-                                        "computed": false,
-                                        "object": {
-                                          "type": "CallExpression",
-                                          "callee": {
-                                            "type": "MemberExpression",
-                                            "computed": false,
-                                            "object": {
-                                              "type": "Identifier",
-                                              "name": "IO"
-                                            },
-                                            "property": {
-                                              "type": "Identifier",
-                                              "name": "getLine"
-                                            }
-                                          },
-                                          "arguments": [
-                                            {
-                                              "type": "Literal",
-                                              "value": "random string",
-                                              "raw": "random string",
-                                              "sType": "string"
-                                            }
-                                          ],
-                                          "nextParams": [
-                                            {
-                                              "type": "Identifier",
-                                              "name": "a"
-                                            }
-                                          ]
-                                        },
-                                        "property": {
-                                          "type": "Identifier",
-                                          "name": "map"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "type": "ArrowFunctionExpression",
-                                          "id": null,
-                                          "params": [
-                                            {
-                                              "type": "Identifier",
-                                              "name": "a"
-                                            }
-                                          ],
-                                          "body": {
-                                            "type": "ArrayExpression",
-                                            "elements": [
-                                              {
-                                                "type": "Identifier",
-                                                "name": "a"
-                                              }
-                                            ]
-                                          },
-                                          "generator": false,
-                                          "expression": true
-                                        }
-                                      ],
-                                      "nextParams": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "a"
-                                        }
-                                      ]
-                                    },
-                                    "property": {
-                                      "type": "Identifier",
-                                      "name": "bind"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "type": "ArrowFunctionExpression",
-                                      "id": null,
-                                      "params": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "a"
-                                        }
-                                      ],
-                                      "body": {
-                                        "type": "CallExpression",
-                                        "callee": {
-                                          "type": "MemberExpression",
-                                          "computed": false,
-                                          "object": {
-                                            "type": "Identifier",
-                                            "name": "IO"
-                                          },
-                                          "property": {
-                                            "type": "Identifier",
-                                            "name": "createIO"
-                                          }
-                                        },
-                                        "arguments": [
-                                          {
-                                            "type": "ArrowFunctionExpression",
-                                            "id": null,
-                                            "params": [
-                                              {
-                                                "type": "Identifier",
-                                                "name": "cb"
-                                              }
-                                            ],
-                                            "body": {
-                                              "type": "CallExpression",
-                                              "callee": {
-                                                "type": "Identifier",
-                                                "name": "request"
-                                              },
-                                              "arguments": [
-                                                {
-                                                  "type": "Literal",
-                                                  "value": "http://google.com",
-                                                  "raw": "http://google.com",
-                                                  "sType": "string"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "cb"
-                                                }
-                                              ]
-                                            },
-                                            "generator": false,
-                                            "expression": true
-                                          }
-                                        ],
-                                        "nextParams": [
-                                          {
-                                            "type": "Identifier",
-                                            "name": "a"
-                                          },
-                                          {
-                                            "type": "Identifier",
-                                            "name": "err"
-                                          },
-                                          {
-                                            "type": "Identifier",
-                                            "name": "res"
-                                          }
-                                        ]
-                                      },
-                                      "generator": false,
-                                      "expression": true
-                                    }
-                                  ],
-                                  "nextParams": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "a"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "err"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "res"
-                                    }
-                                  ]
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "name": "map"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "type": "ArrowFunctionExpression",
-                                  "id": null,
-                                  "params": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "a"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "err"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "res"
-                                    }
-                                  ],
-                                  "body": {
-                                    "type": "ArrayExpression",
-                                    "elements": [
-                                      {
-                                        "type": "Identifier",
-                                        "name": "a"
-                                      },
-                                      {
-                                        "type": "Identifier",
-                                        "name": "err"
-                                      },
-                                      {
-                                        "type": "Identifier",
-                                        "name": "res"
-                                      }
-                                    ]
-                                  },
-                                  "generator": false,
-                                  "expression": true
-                                }
-                              ],
-                              "nextParams": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "a"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "err"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "res"
-                                }
-                              ]
+                              "type": "Identifier",
+                              "name": "IO"
                             },
                             "property": {
                               "type": "Identifier",
-                              "name": "maybeErr"
+                              "name": "getLine"
                             }
                           },
                           "arguments": [
                             {
-                              "type": "ArrowFunctionExpression",
-                              "id": null,
-                              "params": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "a"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "err"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "res"
-                                }
-                              ],
-                              "body": {
-                                "type": "Identifier",
-                                "name": "err"
-                              },
-                              "generator": false,
-                              "expression": true
-                            },
-                            {
-                              "type": "ArrowFunctionExpression",
-                              "id": null,
-                              "params": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "a"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "err"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "res"
-                                }
-                              ],
-                              "body": {
-                                "type": "CallExpression",
-                                "callee": {
-                                  "type": "MemberExpression",
-                                  "computed": false,
-                                  "object": {
-                                    "type": "CallExpression",
-                                    "callee": {
-                                      "type": "MemberExpression",
-                                      "computed": false,
-                                      "object": {
-                                        "type": "Identifier",
-                                        "name": "IO"
-                                      },
-                                      "property": {
-                                        "type": "Identifier",
-                                        "name": "putLine"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "type": "Identifier",
-                                        "name": "err"
-                                      }
-                                    ],
-                                    "nextParams": []
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "name": "then"
-                                  }
-                                },
-                                "arguments": [
-                                  {
-                                    "type": "ArrowFunctionExpression",
-                                    "id": null,
-                                    "params": [],
-                                    "body": {
-                                      "type": "Literal",
-                                      "value": null,
-                                      "raw": "null"
-                                    },
-                                    "generator": false,
-                                    "expression": true
-                                  }
-                                ]
-                              },
-                              "generator": false,
-                              "expression": true
+                              "type": "Literal",
+                              "value": "random string",
+                              "raw": "random string",
+                              "sType": "string"
                             }
                           ],
                           "nextParams": [
                             {
                               "type": "Identifier",
                               "name": "a"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "err"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "res"
                             }
                           ]
                         },
                         "property": {
                           "type": "Identifier",
-                          "name": "map"
+                          "name": "bind"
                         }
                       },
                       "arguments": [
@@ -846,200 +523,81 @@
                             {
                               "type": "Identifier",
                               "name": "a"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "err"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "res"
                             }
                           ],
                           "body": {
-                            "type": "BlockStatement",
-                            "body": [
+                            "type": "ArrayExpression",
+                            "elements": [
                               {
-                                "type": "VariableDeclaration",
-                                "declarations": [
-                                  {
-                                    "type": "VariableDeclarator",
-                                    "id": {
-                                      "type": "Identifier",
-                                      "name": "ob"
-                                    },
-                                    "init": {
-                                      "type": "ObjectExpression",
-                                      "properties": [
-                                        {
-                                          "type": "Property",
-                                          "key": {
-                                            "type": "Identifier",
-                                            "name": "f"
-                                          },
-                                          "computed": false,
-                                          "value": {
-                                            "type": "Literal",
-                                            "value": 25,
-                                            "raw": "25",
-                                            "sType": "number"
-                                          },
-                                          "kind": "init",
-                                          "method": false,
-                                          "shorthand": false
-                                        }
-                                      ]
-                                    }
-                                  }
-                                ],
-                                "kind": "let"
+                                "type": "Identifier",
+                                "name": "a"
                               },
                               {
-                                "type": "ExpressionStatement",
-                                "expression": {
-                                  "type": "CallExpression",
-                                  "callee": {
-                                    "type": "MemberExpression",
-                                    "computed": false,
-                                    "object": {
-                                      "type": "Identifier",
-                                      "name": "Object"
-                                    },
-                                    "property": {
-                                      "type": "Identifier",
-                                      "name": "defineProperty"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "ob"
-                                    },
-                                    {
-                                      "type": "Literal",
-                                      "value": "b",
-                                      "raw": "b",
-                                      "sType": "string"
-                                    },
-                                    {
-                                      "type": "ObjectExpression",
-                                      "properties": [
-                                        {
-                                          "type": "Property",
-                                          "key": {
-                                            "type": "Identifier",
-                                            "name": "value"
-                                          },
-                                          "computed": false,
-                                          "value": {
-                                            "type": "Literal",
-                                            "value": 45,
-                                            "raw": "45",
-                                            "sType": "number"
-                                          },
-                                          "kind": "init",
-                                          "method": false,
-                                          "shorthand": false
-                                        },
-                                        {
-                                          "type": "Property",
-                                          "key": {
-                                            "type": "Identifier",
-                                            "name": "enumerable"
-                                          },
-                                          "computed": false,
-                                          "value": {
-                                            "type": "Literal",
-                                            "value": true,
-                                            "raw": "true"
-                                          },
-                                          "kind": "init",
-                                          "method": false,
-                                          "shorthand": false
-                                        },
-                                        {
-                                          "type": "Property",
-                                          "key": {
-                                            "type": "Identifier",
-                                            "name": "writable"
-                                          },
-                                          "computed": false,
-                                          "value": {
-                                            "type": "Literal",
-                                            "value": true,
-                                            "raw": "true"
-                                          },
-                                          "kind": "init",
-                                          "method": false,
-                                          "shorthand": false
-                                        },
-                                        {
-                                          "type": "Property",
-                                          "key": {
-                                            "type": "Identifier",
-                                            "name": "configurable"
-                                          },
-                                          "computed": false,
-                                          "value": {
-                                            "type": "Literal",
-                                            "value": true,
-                                            "raw": "true"
-                                          },
-                                          "kind": "init",
-                                          "method": false,
-                                          "shorthand": false
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              },
-                              {
-                                "type": "UnaryExpression",
-                                "operator": "delete",
-                                "argument": {
+                                "type": "CallExpression",
+                                "callee": {
                                   "type": "MemberExpression",
                                   "computed": false,
                                   "object": {
                                     "type": "Identifier",
-                                    "name": "ob"
+                                    "name": "IO"
                                   },
                                   "property": {
                                     "type": "Identifier",
-                                    "name": "b",
-                                    "isSubscript": false
+                                    "name": "createIO"
                                   }
                                 },
-                                "prefix": true
-                              },
-                              {
-                                "type": "ReturnStatement",
-                                "argument": {
-                                  "type": "ArrayExpression",
-                                  "elements": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "a"
+                                "arguments": [
+                                  {
+                                    "type": "ArrowFunctionExpression",
+                                    "id": null,
+                                    "params": [
+                                      {
+                                        "type": "Identifier",
+                                        "name": "cb"
+                                      }
+                                    ],
+                                    "body": {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "Identifier",
+                                        "name": "request"
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Literal",
+                                          "value": "http://google.com",
+                                          "raw": "http://google.com",
+                                          "sType": "string"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "cb"
+                                        }
+                                      ]
                                     },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "err"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "res"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "ob"
-                                    }
-                                  ]
-                                }
+                                    "generator": false,
+                                    "expression": true
+                                  }
+                                ],
+                                "nextParams": [
+                                  {
+                                    "type": "Identifier",
+                                    "name": "a"
+                                  },
+                                  {
+                                    "type": "Identifier",
+                                    "name": "err"
+                                  },
+                                  {
+                                    "type": "Identifier",
+                                    "name": "res"
+                                  }
+                                ]
                               }
                             ]
                           },
                           "generator": false,
-                          "expression": false
+                          "expression": true
                         }
                       ],
                       "nextParams": [
@@ -1082,38 +640,289 @@
                         {
                           "type": "Identifier",
                           "name": "res"
-                        },
-                        {
-                          "type": "Identifier",
-                          "name": "ob"
                         }
                       ],
                       "body": {
-                        "type": "CallExpression",
-                        "callee": {
-                          "type": "MemberExpression",
-                          "computed": false,
-                          "object": {
-                            "type": "Identifier",
-                            "name": "IO"
-                          },
-                          "property": {
-                            "type": "Identifier",
-                            "name": "putLine"
-                          }
-                        },
-                        "arguments": [
+                        "type": "BlockStatement",
+                        "body": [
                           {
-                            "type": "MemberExpression",
-                            "computed": false,
-                            "object": {
-                              "type": "Identifier",
-                              "name": "res"
+                            "type": "IfStatement",
+                            "test": {
+                              "type": "BinaryExpression",
+                              "operator": "instanceof",
+                              "sType": "any",
+                              "left": {
+                                "type": "Identifier",
+                                "name": "err"
+                              },
+                              "right": {
+                                "type": "Identifier",
+                                "name": "Error"
+                              }
                             },
-                            "property": {
-                              "type": "Identifier",
-                              "name": "body",
-                              "isSubscript": false
+                            "consequent": {
+                              "type": "BlockStatement",
+                              "body": [
+                                {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "MemberExpression",
+                                        "computed": false,
+                                        "object": {
+                                          "type": "Identifier",
+                                          "name": "IO"
+                                        },
+                                        "property": {
+                                          "type": "Identifier",
+                                          "name": "putLine"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "err"
+                                        }
+                                      ],
+                                      "nextParams": []
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "then"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "ArrowFunctionExpression",
+                                      "id": null,
+                                      "params": [],
+                                      "body": {
+                                        "type": "Literal",
+                                        "value": null,
+                                        "raw": "null"
+                                      },
+                                      "generator": false,
+                                      "expression": true
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "ReturnStatement",
+                                  "argument": null
+                                }
+                              ]
+                            },
+                            "alternate": null
+                          },
+                          {
+                            "type": "VariableDeclaration",
+                            "declarations": [
+                              {
+                                "type": "VariableDeclarator",
+                                "id": {
+                                  "type": "Identifier",
+                                  "name": "ob"
+                                },
+                                "init": {
+                                  "type": "ObjectExpression",
+                                  "properties": [
+                                    {
+                                      "type": "Property",
+                                      "key": {
+                                        "type": "Identifier",
+                                        "name": "f"
+                                      },
+                                      "computed": false,
+                                      "value": {
+                                        "type": "Literal",
+                                        "value": 25,
+                                        "raw": "25",
+                                        "sType": "number"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "kind": "let"
+                          },
+                          {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                              "type": "CallExpression",
+                              "callee": {
+                                "type": "MemberExpression",
+                                "computed": false,
+                                "object": {
+                                  "type": "Identifier",
+                                  "name": "Object"
+                                },
+                                "property": {
+                                  "type": "Identifier",
+                                  "name": "defineProperty"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "ob"
+                                },
+                                {
+                                  "type": "Literal",
+                                  "value": "b",
+                                  "raw": "b",
+                                  "sType": "string"
+                                },
+                                {
+                                  "type": "ObjectExpression",
+                                  "properties": [
+                                    {
+                                      "type": "Property",
+                                      "key": {
+                                        "type": "Identifier",
+                                        "name": "value"
+                                      },
+                                      "computed": false,
+                                      "value": {
+                                        "type": "Literal",
+                                        "value": 45,
+                                        "raw": "45",
+                                        "sType": "number"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": false
+                                    },
+                                    {
+                                      "type": "Property",
+                                      "key": {
+                                        "type": "Identifier",
+                                        "name": "enumerable"
+                                      },
+                                      "computed": false,
+                                      "value": {
+                                        "type": "Literal",
+                                        "value": true,
+                                        "raw": "true"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": false
+                                    },
+                                    {
+                                      "type": "Property",
+                                      "key": {
+                                        "type": "Identifier",
+                                        "name": "writable"
+                                      },
+                                      "computed": false,
+                                      "value": {
+                                        "type": "Literal",
+                                        "value": true,
+                                        "raw": "true"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": false
+                                    },
+                                    {
+                                      "type": "Property",
+                                      "key": {
+                                        "type": "Identifier",
+                                        "name": "configurable"
+                                      },
+                                      "computed": false,
+                                      "value": {
+                                        "type": "Literal",
+                                        "value": true,
+                                        "raw": "true"
+                                      },
+                                      "kind": "init",
+                                      "method": false,
+                                      "shorthand": false
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "UnaryExpression",
+                            "operator": "delete",
+                            "argument": {
+                              "type": "MemberExpression",
+                              "computed": false,
+                              "object": {
+                                "type": "Identifier",
+                                "name": "ob"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "name": "b",
+                                "isSubscript": false
+                              }
+                            },
+                            "prefix": true
+                          },
+                          {
+                            "type": "ReturnStatement",
+                            "argument": {
+                              "type": "ArrayExpression",
+                              "elements": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "a"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "err"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "res"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "ob"
+                                },
+                                {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "name": "IO"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "putLine"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "computed": false,
+                                      "object": {
+                                        "type": "Identifier",
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "name": "body",
+                                        "isSubscript": false
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
                             }
                           }
                         ]
@@ -1274,28 +1083,37 @@
                   }
                 ],
                 "body": {
-                  "type": "CallExpression",
-                  "callee": {
-                    "type": "MemberExpression",
-                    "computed": false,
-                    "object": {
-                      "type": "Identifier",
-                      "name": "IO"
-                    },
-                    "property": {
-                      "type": "Identifier",
-                      "name": "putLine"
-                    }
-                  },
-                  "arguments": [
+                  "type": "ArrayExpression",
+                  "elements": [
                     {
                       "type": "Identifier",
                       "name": "body"
+                    },
+                    {
+                      "type": "CallExpression",
+                      "callee": {
+                        "type": "MemberExpression",
+                        "computed": false,
+                        "object": {
+                          "type": "Identifier",
+                          "name": "IO"
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "name": "putLine"
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "type": "Identifier",
+                          "name": "body"
+                        }
+                      ]
                     }
                   ]
                 },
                 "generator": false,
-                "expression": false
+                "expression": true
               }
             ],
             "nextParams": [
@@ -1314,12 +1132,7 @@
           {
             "type": "ArrowFunctionExpression",
             "id": null,
-            "params": [
-              {
-                "type": "Identifier",
-                "name": "body"
-              }
-            ],
+            "params": [],
             "body": {
               "type": "ArrayExpression",
               "elements": []

--- a/test/assert/doBlock.json
+++ b/test/assert/doBlock.json
@@ -30,60 +30,20 @@
                     "type": "MemberExpression",
                     "computed": false,
                     "object": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "IO"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "getLine"
-                        }
-                      },
-                      "arguments": [
-                        {
-                          "type": "Literal",
-                          "value": "enter value:",
-                          "raw": "enter value:",
-                          "sType": "string"
-                        }
-                      ],
-                      "nextParams": [
-                        {
-                          "type": "Identifier",
-                          "name": "g"
-                        }
-                      ]
+                      "type": "Identifier",
+                      "name": "IO"
                     },
                     "property": {
                       "type": "Identifier",
-                      "name": "map"
+                      "name": "getLine"
                     }
                   },
                   "arguments": [
                     {
-                      "type": "ArrowFunctionExpression",
-                      "id": null,
-                      "params": [
-                        {
-                          "type": "Identifier",
-                          "name": "g"
-                        }
-                      ],
-                      "body": {
-                        "type": "ArrayExpression",
-                        "elements": [
-                          {
-                            "type": "Identifier",
-                            "name": "g"
-                          }
-                        ]
-                      },
-                      "generator": false,
-                      "expression": true
+                      "type": "Literal",
+                      "value": "enter value:",
+                      "raw": "enter value:",
+                      "sType": "string"
                     }
                   ],
                   "nextParams": [
@@ -216,28 +176,37 @@
                       }
                     ],
                     "body": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "IO"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "putLine"
-                        }
-                      },
-                      "arguments": [
+                      "type": "ArrayExpression",
+                      "elements": [
                         {
                           "type": "Identifier",
                           "name": "c"
+                        },
+                        {
+                          "type": "CallExpression",
+                          "callee": {
+                            "type": "MemberExpression",
+                            "computed": false,
+                            "object": {
+                              "type": "Identifier",
+                              "name": "IO"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "name": "putLine"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "Identifier",
+                              "name": "c"
+                            }
+                          ]
                         }
                       ]
                     },
                     "generator": false,
-                    "expression": false
+                    "expression": true
                   }
                 ],
                 "nextParams": [
@@ -256,12 +225,7 @@
               {
                 "type": "ArrowFunctionExpression",
                 "id": null,
-                "params": [
-                  {
-                    "type": "Identifier",
-                    "name": "c"
-                  }
-                ],
+                "params": [],
                 "body": {
                   "type": "ArrayExpression",
                   "elements": []

--- a/test/assert/example.json
+++ b/test/assert/example.json
@@ -159,147 +159,20 @@
                         "type": "MemberExpression",
                         "computed": false,
                         "object": {
-                          "type": "CallExpression",
-                          "callee": {
-                            "type": "MemberExpression",
-                            "computed": false,
-                            "object": {
-                              "type": "CallExpression",
-                              "callee": {
-                                "type": "MemberExpression",
-                                "computed": false,
-                                "object": {
-                                  "type": "Identifier",
-                                  "name": "IO"
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "name": "getLine"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "type": "Literal",
-                                  "value": "enter value for factorial: ",
-                                  "raw": "enter value for factorial: ",
-                                  "sType": "string"
-                                }
-                              ],
-                              "nextParams": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "num"
-                                }
-                              ]
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "name": "map"
-                            }
-                          },
-                          "arguments": [
-                            {
-                              "type": "ArrowFunctionExpression",
-                              "id": null,
-                              "params": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "num"
-                                }
-                              ],
-                              "body": {
-                                "type": "ArrayExpression",
-                                "elements": [
-                                  {
-                                    "type": "Identifier",
-                                    "name": "num"
-                                  }
-                                ]
-                              },
-                              "generator": false,
-                              "expression": true
-                            }
-                          ],
-                          "nextParams": [
-                            {
-                              "type": "Identifier",
-                              "name": "num"
-                            }
-                          ]
+                          "type": "Identifier",
+                          "name": "IO"
                         },
                         "property": {
                           "type": "Identifier",
-                          "name": "map"
+                          "name": "getLine"
                         }
                       },
                       "arguments": [
                         {
-                          "type": "ArrowFunctionExpression",
-                          "id": null,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "name": "num"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "body": [
-                              {
-                                "type": "VariableDeclaration",
-                                "declarations": [
-                                  {
-                                    "type": "VariableDeclarator",
-                                    "id": {
-                                      "type": "Identifier",
-                                      "name": "val"
-                                    },
-                                    "init": {
-                                      "type": "CallExpression",
-                                      "callee": {
-                                        "type": "Identifier",
-                                        "name": "fact"
-                                      },
-                                      "arguments": [
-                                        {
-                                          "type": "CallExpression",
-                                          "callee": {
-                                            "type": "Identifier",
-                                            "name": "parseInt"
-                                          },
-                                          "arguments": [
-                                            {
-                                              "type": "Identifier",
-                                              "name": "num"
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  }
-                                ],
-                                "kind": "let"
-                              },
-                              {
-                                "type": "ReturnStatement",
-                                "argument": {
-                                  "type": "ArrayExpression",
-                                  "elements": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "num"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "val"
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          },
-                          "generator": false,
-                          "expression": false
+                          "type": "Literal",
+                          "value": "enter value for factorial: ",
+                          "raw": "enter value for factorial: ",
+                          "sType": "string"
                         }
                       ],
                       "nextParams": [
@@ -326,30 +199,82 @@
                         {
                           "type": "Identifier",
                           "name": "num"
-                        },
-                        {
-                          "type": "Identifier",
-                          "name": "val"
                         }
                       ],
                       "body": {
-                        "type": "CallExpression",
-                        "callee": {
-                          "type": "MemberExpression",
-                          "computed": false,
-                          "object": {
-                            "type": "Identifier",
-                            "name": "IO"
-                          },
-                          "property": {
-                            "type": "Identifier",
-                            "name": "putLine"
-                          }
-                        },
-                        "arguments": [
+                        "type": "BlockStatement",
+                        "body": [
                           {
-                            "type": "Identifier",
-                            "name": "val"
+                            "type": "VariableDeclaration",
+                            "declarations": [
+                              {
+                                "type": "VariableDeclarator",
+                                "id": {
+                                  "type": "Identifier",
+                                  "name": "val"
+                                },
+                                "init": {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "Identifier",
+                                    "name": "fact"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "Identifier",
+                                        "name": "parseInt"
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "num"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "kind": "let"
+                          },
+                          {
+                            "type": "ReturnStatement",
+                            "argument": {
+                              "type": "ArrayExpression",
+                              "elements": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "num"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "val"
+                                },
+                                {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "name": "IO"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "putLine"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "val"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
                           }
                         ]
                       },
@@ -474,311 +399,20 @@
                         "object": {
                           "type": "CallExpression",
                           "callee": {
-                            "type": "MemberExpression",
-                            "computed": false,
-                            "object": {
-                              "type": "CallExpression",
-                              "callee": {
-                                "type": "MemberExpression",
-                                "computed": false,
-                                "object": {
-                                  "type": "CallExpression",
-                                  "callee": {
-                                    "type": "MemberExpression",
-                                    "computed": false,
-                                    "object": {
-                                      "type": "CallExpression",
-                                      "callee": {
-                                        "type": "Identifier",
-                                        "name": "computeFact"
-                                      },
-                                      "arguments": [],
-                                      "nextParams": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "data"
-                                        }
-                                      ]
-                                    },
-                                    "property": {
-                                      "type": "Identifier",
-                                      "name": "map"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "type": "ArrowFunctionExpression",
-                                      "id": null,
-                                      "params": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "data"
-                                        }
-                                      ],
-                                      "body": {
-                                        "type": "BlockStatement",
-                                        "body": [
-                                          {
-                                            "type": "VariableDeclaration",
-                                            "declarations": [
-                                              {
-                                                "type": "VariableDeclarator",
-                                                "id": {
-                                                  "type": "Identifier",
-                                                  "name": "link"
-                                                },
-                                                "init": {
-                                                  "type": "BinaryExpression",
-                                                  "operator": "+",
-                                                  "sType": "string",
-                                                  "left": {
-                                                    "type": "Literal",
-                                                    "value": "http://artii.herokuapp.com/make?text=",
-                                                    "raw": "http://artii.herokuapp.com/make?text=",
-                                                    "sType": "string"
-                                                  },
-                                                  "right": {
-                                                    "type": "Identifier",
-                                                    "name": "data"
-                                                  }
-                                                }
-                                              }
-                                            ],
-                                            "kind": "let"
-                                          },
-                                          {
-                                            "type": "ReturnStatement",
-                                            "argument": {
-                                              "type": "ArrayExpression",
-                                              "elements": [
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "data"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "link"
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "generator": false,
-                                      "expression": false
-                                    }
-                                  ],
-                                  "nextParams": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "data"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "link"
-                                    }
-                                  ]
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "name": "bind"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "type": "ArrowFunctionExpression",
-                                  "id": null,
-                                  "params": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "data"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "link"
-                                    }
-                                  ],
-                                  "body": {
-                                    "type": "CallExpression",
-                                    "callee": {
-                                      "type": "MemberExpression",
-                                      "computed": false,
-                                      "object": {
-                                        "type": "Identifier",
-                                        "name": "IO"
-                                      },
-                                      "property": {
-                                        "type": "Identifier",
-                                        "name": "createIO"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "type": "ArrowFunctionExpression",
-                                        "id": null,
-                                        "params": [
-                                          {
-                                            "type": "Identifier",
-                                            "name": "cb"
-                                          }
-                                        ],
-                                        "body": {
-                                          "type": "CallExpression",
-                                          "callee": {
-                                            "type": "Identifier",
-                                            "name": "request"
-                                          },
-                                          "arguments": [
-                                            {
-                                              "type": "Identifier",
-                                              "name": "link"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "cb"
-                                            }
-                                          ]
-                                        },
-                                        "generator": false,
-                                        "expression": true
-                                      }
-                                    ],
-                                    "nextParams": [
-                                      {
-                                        "type": "Identifier",
-                                        "name": "data"
-                                      },
-                                      {
-                                        "type": "Identifier",
-                                        "name": "link"
-                                      },
-                                      {
-                                        "type": "Identifier",
-                                        "name": "err"
-                                      },
-                                      {
-                                        "type": "Identifier",
-                                        "name": "res"
-                                      },
-                                      {
-                                        "type": "Identifier",
-                                        "name": "body"
-                                      }
-                                    ]
-                                  },
-                                  "generator": false,
-                                  "expression": true
-                                }
-                              ],
-                              "nextParams": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "data"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "link"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "err"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "res"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "body"
-                                }
-                              ]
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "name": "map"
-                            }
+                            "type": "Identifier",
+                            "name": "computeFact"
                           },
-                          "arguments": [
-                            {
-                              "type": "ArrowFunctionExpression",
-                              "id": null,
-                              "params": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "data"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "link"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "err"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "res"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "body"
-                                }
-                              ],
-                              "body": {
-                                "type": "ArrayExpression",
-                                "elements": [
-                                  {
-                                    "type": "Identifier",
-                                    "name": "data"
-                                  },
-                                  {
-                                    "type": "Identifier",
-                                    "name": "link"
-                                  },
-                                  {
-                                    "type": "Identifier",
-                                    "name": "err"
-                                  },
-                                  {
-                                    "type": "Identifier",
-                                    "name": "res"
-                                  },
-                                  {
-                                    "type": "Identifier",
-                                    "name": "body"
-                                  }
-                                ]
-                              },
-                              "generator": false,
-                              "expression": true
-                            }
-                          ],
+                          "arguments": [],
                           "nextParams": [
                             {
                               "type": "Identifier",
                               "name": "data"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "link"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "err"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "res"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "body"
                             }
                           ]
                         },
                         "property": {
                           "type": "Identifier",
-                          "name": "maybeErr"
+                          "name": "bind"
                         }
                       },
                       "arguments": [
@@ -789,105 +423,127 @@
                             {
                               "type": "Identifier",
                               "name": "data"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "link"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "err"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "res"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "body"
                             }
                           ],
                           "body": {
-                            "type": "Identifier",
-                            "name": "err"
-                          },
-                          "generator": false,
-                          "expression": true
-                        },
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "id": null,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "name": "data"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "link"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "err"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "res"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "body"
-                            }
-                          ],
-                          "body": {
-                            "type": "CallExpression",
-                            "callee": {
-                              "type": "MemberExpression",
-                              "computed": false,
-                              "object": {
-                                "type": "CallExpression",
-                                "callee": {
-                                  "type": "MemberExpression",
-                                  "computed": false,
-                                  "object": {
-                                    "type": "Identifier",
-                                    "name": "IO"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "name": "putLine"
-                                  }
-                                },
-                                "arguments": [
+                            "type": "BlockStatement",
+                            "body": [
+                              {
+                                "type": "VariableDeclaration",
+                                "declarations": [
                                   {
-                                    "type": "Identifier",
-                                    "name": "err"
+                                    "type": "VariableDeclarator",
+                                    "id": {
+                                      "type": "Identifier",
+                                      "name": "link"
+                                    },
+                                    "init": {
+                                      "type": "BinaryExpression",
+                                      "operator": "+",
+                                      "sType": "string",
+                                      "left": {
+                                        "type": "Literal",
+                                        "value": "http://artii.herokuapp.com/make?text=",
+                                        "raw": "http://artii.herokuapp.com/make?text=",
+                                        "sType": "string"
+                                      },
+                                      "right": {
+                                        "type": "Identifier",
+                                        "name": "data"
+                                      }
+                                    }
                                   }
                                 ],
-                                "nextParams": []
+                                "kind": "let"
                               },
-                              "property": {
-                                "type": "Identifier",
-                                "name": "then"
-                              }
-                            },
-                            "arguments": [
                               {
-                                "type": "ArrowFunctionExpression",
-                                "id": null,
-                                "params": [],
-                                "body": {
-                                  "type": "Literal",
-                                  "value": null,
-                                  "raw": "null"
-                                },
-                                "generator": false,
-                                "expression": true
+                                "type": "ReturnStatement",
+                                "argument": {
+                                  "type": "ArrayExpression",
+                                  "elements": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "data"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "link"
+                                    },
+                                    {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "MemberExpression",
+                                        "computed": false,
+                                        "object": {
+                                          "type": "Identifier",
+                                          "name": "IO"
+                                        },
+                                        "property": {
+                                          "type": "Identifier",
+                                          "name": "createIO"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "ArrowFunctionExpression",
+                                          "id": null,
+                                          "params": [
+                                            {
+                                              "type": "Identifier",
+                                              "name": "cb"
+                                            }
+                                          ],
+                                          "body": {
+                                            "type": "CallExpression",
+                                            "callee": {
+                                              "type": "Identifier",
+                                              "name": "request"
+                                            },
+                                            "arguments": [
+                                              {
+                                                "type": "Identifier",
+                                                "name": "link"
+                                              },
+                                              {
+                                                "type": "Identifier",
+                                                "name": "cb"
+                                              }
+                                            ]
+                                          },
+                                          "generator": false,
+                                          "expression": true
+                                        }
+                                      ],
+                                      "nextParams": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "data"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "link"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "err"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "res"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "body"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
                               }
                             ]
                           },
                           "generator": false,
-                          "expression": true
+                          "expression": false
                         }
                       ],
                       "nextParams": [
@@ -945,23 +601,129 @@
                         }
                       ],
                       "body": {
-                        "type": "CallExpression",
-                        "callee": {
-                          "type": "MemberExpression",
-                          "computed": false,
-                          "object": {
-                            "type": "Identifier",
-                            "name": "IO"
-                          },
-                          "property": {
-                            "type": "Identifier",
-                            "name": "putLine"
-                          }
-                        },
-                        "arguments": [
+                        "type": "BlockStatement",
+                        "body": [
                           {
-                            "type": "Identifier",
-                            "name": "body"
+                            "type": "IfStatement",
+                            "test": {
+                              "type": "BinaryExpression",
+                              "operator": "instanceof",
+                              "sType": "any",
+                              "left": {
+                                "type": "Identifier",
+                                "name": "err"
+                              },
+                              "right": {
+                                "type": "Identifier",
+                                "name": "Error"
+                              }
+                            },
+                            "consequent": {
+                              "type": "BlockStatement",
+                              "body": [
+                                {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "MemberExpression",
+                                        "computed": false,
+                                        "object": {
+                                          "type": "Identifier",
+                                          "name": "IO"
+                                        },
+                                        "property": {
+                                          "type": "Identifier",
+                                          "name": "putLine"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "err"
+                                        }
+                                      ],
+                                      "nextParams": []
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "then"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "ArrowFunctionExpression",
+                                      "id": null,
+                                      "params": [],
+                                      "body": {
+                                        "type": "Literal",
+                                        "value": null,
+                                        "raw": "null"
+                                      },
+                                      "generator": false,
+                                      "expression": true
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "ReturnStatement",
+                                  "argument": null
+                                }
+                              ]
+                            },
+                            "alternate": null
+                          },
+                          {
+                            "type": "ReturnStatement",
+                            "argument": {
+                              "type": "ArrayExpression",
+                              "elements": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "data"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "link"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "err"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "res"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "body"
+                                },
+                                {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "name": "IO"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "putLine"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "body"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
                           }
                         ]
                       },

--- a/test/assert/expressEx.json
+++ b/test/assert/expressEx.json
@@ -106,255 +106,130 @@
               "type": "MemberExpression",
               "computed": false,
               "object": {
-                "type": "CallExpression",
-                "callee": {
-                  "type": "MemberExpression",
-                  "computed": false,
-                  "object": {
-                    "type": "CallExpression",
-                    "callee": {
-                      "type": "MemberExpression",
-                      "computed": false,
-                      "object": {
+                "type": "Identifier",
+                "name": "IO"
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "createIO"
+              }
+            },
+            "arguments": [
+              {
+                "type": "ArrowFunctionExpression",
+                "id": null,
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "name": "cb"
+                  }
+                ],
+                "body": {
+                  "type": "CallExpression",
+                  "callee": {
+                    "type": "MemberExpression",
+                    "computed": false,
+                    "object": {
+                      "type": "Identifier",
+                      "name": "app"
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "name": "get",
+                      "isSubscript": false
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Literal",
+                      "value": "/",
+                      "raw": "/",
+                      "sType": "string"
+                    },
+                    {
+                      "type": "Identifier",
+                      "name": "cb"
+                    }
+                  ]
+                },
+                "generator": false,
+                "expression": true
+              }
+            ],
+            "nextParams": [
+              {
+                "type": "Identifier",
+                "name": "req"
+              },
+              {
+                "type": "Identifier",
+                "name": "res"
+              }
+            ]
+          },
+          "property": {
+            "type": "Identifier",
+            "name": "then"
+          }
+        },
+        "arguments": [
+          {
+            "type": "ArrowFunctionExpression",
+            "id": null,
+            "params": [
+              {
+                "type": "Identifier",
+                "name": "req"
+              },
+              {
+                "type": "Identifier",
+                "name": "res"
+              }
+            ],
+            "body": {
+              "type": "BlockStatement",
+              "body": [
+                {
+                  "type": "VariableDeclaration",
+                  "declarations": [
+                    {
+                      "type": "VariableDeclarator",
+                      "id": {
+                        "type": "Identifier",
+                        "name": "val"
+                      },
+                      "init": {
                         "type": "CallExpression",
                         "callee": {
-                          "type": "MemberExpression",
-                          "computed": false,
-                          "object": {
-                            "type": "CallExpression",
-                            "callee": {
-                              "type": "MemberExpression",
-                              "computed": false,
-                              "object": {
-                                "type": "Identifier",
-                                "name": "IO"
-                              },
-                              "property": {
-                                "type": "Identifier",
-                                "name": "createIO"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "type": "ArrowFunctionExpression",
-                                "id": null,
-                                "params": [
-                                  {
-                                    "type": "Identifier",
-                                    "name": "cb"
-                                  }
-                                ],
-                                "body": {
-                                  "type": "CallExpression",
-                                  "callee": {
-                                    "type": "MemberExpression",
-                                    "computed": false,
-                                    "object": {
-                                      "type": "Identifier",
-                                      "name": "app"
-                                    },
-                                    "property": {
-                                      "type": "Identifier",
-                                      "name": "get",
-                                      "isSubscript": false
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "type": "Literal",
-                                      "value": "/",
-                                      "raw": "/",
-                                      "sType": "string"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "cb"
-                                    }
-                                  ]
-                                },
-                                "generator": false,
-                                "expression": true
-                              }
-                            ],
-                            "nextParams": [
-                              {
-                                "type": "Identifier",
-                                "name": "req"
-                              },
-                              {
-                                "type": "Identifier",
-                                "name": "res"
-                              }
-                            ]
-                          },
-                          "property": {
-                            "type": "Identifier",
-                            "name": "map"
-                          }
+                          "type": "Identifier",
+                          "name": "sum"
                         },
                         "arguments": [
                           {
-                            "type": "ArrowFunctionExpression",
-                            "id": null,
-                            "params": [
-                              {
-                                "type": "Identifier",
-                                "name": "req"
-                              },
-                              {
-                                "type": "Identifier",
-                                "name": "res"
-                              }
-                            ],
-                            "body": {
-                              "type": "ArrayExpression",
-                              "elements": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "req"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "res"
-                                }
-                              ]
-                            },
-                            "generator": false,
-                            "expression": true
-                          }
-                        ],
-                        "nextParams": [
-                          {
-                            "type": "Identifier",
-                            "name": "req"
+                            "type": "Literal",
+                            "value": 5,
+                            "raw": "5",
+                            "sType": "number"
                           },
                           {
-                            "type": "Identifier",
-                            "name": "res"
+                            "type": "Literal",
+                            "value": 15,
+                            "raw": "15",
+                            "sType": "number"
                           }
                         ]
-                      },
-                      "property": {
-                        "type": "Identifier",
-                        "name": "map"
                       }
-                    },
-                    "arguments": [
-                      {
-                        "type": "ArrowFunctionExpression",
-                        "id": null,
-                        "params": [
-                          {
-                            "type": "Identifier",
-                            "name": "req"
-                          },
-                          {
-                            "type": "Identifier",
-                            "name": "res"
-                          }
-                        ],
-                        "body": {
-                          "type": "BlockStatement",
-                          "body": [
-                            {
-                              "type": "VariableDeclaration",
-                              "declarations": [
-                                {
-                                  "type": "VariableDeclarator",
-                                  "id": {
-                                    "type": "Identifier",
-                                    "name": "val"
-                                  },
-                                  "init": {
-                                    "type": "CallExpression",
-                                    "callee": {
-                                      "type": "Identifier",
-                                      "name": "sum"
-                                    },
-                                    "arguments": [
-                                      {
-                                        "type": "Literal",
-                                        "value": 5,
-                                        "raw": "5",
-                                        "sType": "number"
-                                      },
-                                      {
-                                        "type": "Literal",
-                                        "value": 15,
-                                        "raw": "15",
-                                        "sType": "number"
-                                      }
-                                    ]
-                                  }
-                                }
-                              ],
-                              "kind": "let"
-                            },
-                            {
-                              "type": "ReturnStatement",
-                              "argument": {
-                                "type": "ArrayExpression",
-                                "elements": [
-                                  {
-                                    "type": "Identifier",
-                                    "name": "req"
-                                  },
-                                  {
-                                    "type": "Identifier",
-                                    "name": "res"
-                                  },
-                                  {
-                                    "type": "Identifier",
-                                    "name": "val"
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        },
-                        "generator": false,
-                        "expression": false
-                      }
-                    ],
-                    "nextParams": [
-                      {
-                        "type": "Identifier",
-                        "name": "req"
-                      },
-                      {
-                        "type": "Identifier",
-                        "name": "res"
-                      },
-                      {
-                        "type": "Identifier",
-                        "name": "val"
-                      }
-                    ]
-                  },
-                  "property": {
-                    "type": "Identifier",
-                    "name": "maybeTrue"
-                  }
+                    }
+                  ],
+                  "kind": "let"
                 },
-                "arguments": [
-                  {
-                    "type": "ArrowFunctionExpression",
-                    "id": null,
-                    "params": [
-                      {
-                        "type": "Identifier",
-                        "name": "req"
-                      },
-                      {
-                        "type": "Identifier",
-                        "name": "res"
-                      },
-                      {
-                        "type": "Identifier",
-                        "name": "val"
-                      }
-                    ],
-                    "body": {
+                {
+                  "type": "IfStatement",
+                  "test": {
+                    "type": "BinaryExpression",
+                    "operator": "===",
+                    "sType": "bool",
+                    "left": {
                       "type": "BinaryExpression",
                       "operator": ">",
                       "sType": "bool",
@@ -380,98 +255,17 @@
                         }
                       }
                     },
-                    "generator": false,
-                    "expression": true
+                    "right": {
+                      "type": "Literal",
+                      "value": true,
+                      "raw": "true",
+                      "sType": "bool"
+                    }
                   },
-                  {
-                    "type": "ArrowFunctionExpression",
-                    "id": null,
-                    "params": [
+                  "consequent": {
+                    "type": "BlockStatement",
+                    "body": [
                       {
-                        "type": "Identifier",
-                        "name": "req"
-                      },
-                      {
-                        "type": "Identifier",
-                        "name": "res"
-                      },
-                      {
-                        "type": "Identifier",
-                        "name": "val"
-                      }
-                    ],
-                    "body": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "res"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "send",
-                          "isSubscript": false
-                        }
-                      },
-                      "arguments": [
-                        {
-                          "type": "Literal",
-                          "value": "welcome",
-                          "raw": "welcome",
-                          "sType": "string"
-                        }
-                      ]
-                    },
-                    "generator": false,
-                    "expression": true
-                  }
-                ],
-                "nextParams": [
-                  {
-                    "type": "Identifier",
-                    "name": "req"
-                  },
-                  {
-                    "type": "Identifier",
-                    "name": "res"
-                  },
-                  {
-                    "type": "Identifier",
-                    "name": "val"
-                  }
-                ]
-              },
-              "property": {
-                "type": "Identifier",
-                "name": "map"
-              }
-            },
-            "arguments": [
-              {
-                "type": "ArrowFunctionExpression",
-                "id": null,
-                "params": [
-                  {
-                    "type": "Identifier",
-                    "name": "req"
-                  },
-                  {
-                    "type": "Identifier",
-                    "name": "res"
-                  },
-                  {
-                    "type": "Identifier",
-                    "name": "val"
-                  }
-                ],
-                "body": {
-                  "type": "BlockStatement",
-                  "body": [
-                    {
-                      "type": "ExpressionStatement",
-                      "expression": {
                         "type": "CallExpression",
                         "callee": {
                           "type": "MemberExpression",
@@ -489,83 +283,51 @@
                         "arguments": [
                           {
                             "type": "Literal",
-                            "value": "Hello World",
-                            "raw": "Hello World",
+                            "value": "welcome",
+                            "raw": "welcome",
                             "sType": "string"
                           }
                         ]
+                      },
+                      {
+                        "type": "ReturnStatement",
+                        "argument": null
+                      }
+                    ]
+                  },
+                  "alternate": null
+                },
+                {
+                  "type": "ExpressionStatement",
+                  "expression": {
+                    "type": "CallExpression",
+                    "callee": {
+                      "type": "MemberExpression",
+                      "computed": false,
+                      "object": {
+                        "type": "Identifier",
+                        "name": "res"
+                      },
+                      "property": {
+                        "type": "Identifier",
+                        "name": "send",
+                        "isSubscript": false
                       }
                     },
-                    {
-                      "type": "ReturnStatement",
-                      "argument": {
-                        "type": "ArrayExpression",
-                        "elements": [
-                          {
-                            "type": "Identifier",
-                            "name": "req"
-                          },
-                          {
-                            "type": "Identifier",
-                            "name": "res"
-                          },
-                          {
-                            "type": "Identifier",
-                            "name": "val"
-                          }
-                        ]
+                    "arguments": [
+                      {
+                        "type": "Literal",
+                        "value": "Hello World",
+                        "raw": "Hello World",
+                        "sType": "string"
                       }
-                    }
-                  ]
-                },
-                "generator": false,
-                "expression": false
-              }
-            ],
-            "nextParams": [
-              {
-                "type": "Identifier",
-                "name": "req"
-              },
-              {
-                "type": "Identifier",
-                "name": "res"
-              },
-              {
-                "type": "Identifier",
-                "name": "val"
-              }
-            ]
-          },
-          "property": {
-            "type": "Identifier",
-            "name": "then"
-          }
-        },
-        "arguments": [
-          {
-            "type": "ArrowFunctionExpression",
-            "id": null,
-            "params": [
-              {
-                "type": "Identifier",
-                "name": "req"
-              },
-              {
-                "type": "Identifier",
-                "name": "res"
-              },
-              {
-                "type": "Identifier",
-                "name": "val"
-              }
-            ],
-            "body": {
-              "type": "ArrayExpression",
-              "elements": []
+                    ]
+                  }
+                }
+              ]
             },
             "generator": false,
-            "expression": true
+            "expression": false
           }
         ],
         "ioParams": [
@@ -576,10 +338,6 @@
           {
             "type": "Identifier",
             "name": "res"
-          },
-          {
-            "type": "Identifier",
-            "name": "val"
           }
         ],
         "sType": "IO"

--- a/test/assert/fileCopy.json
+++ b/test/assert/fileCopy.json
@@ -26,78 +26,38 @@
                       "type": "MemberExpression",
                       "computed": false,
                       "object": {
-                        "type": "CallExpression",
-                        "callee": {
-                          "type": "MemberExpression",
-                          "computed": false,
-                          "object": {
-                            "type": "Identifier",
-                            "name": "IO"
-                          },
-                          "property": {
-                            "type": "Identifier",
-                            "name": "readFile"
-                          }
-                        },
-                        "arguments": [
-                          {
-                            "type": "MemberExpression",
-                            "computed": true,
-                            "object": {
-                              "type": "MemberExpression",
-                              "computed": false,
-                              "object": {
-                                "type": "Identifier",
-                                "name": "process"
-                              },
-                              "property": {
-                                "type": "Identifier",
-                                "name": "argv",
-                                "isSubscript": false
-                              }
-                            },
-                            "property": {
-                              "type": "Literal",
-                              "value": 2,
-                              "raw": "2",
-                              "sType": "number",
-                              "isSubscript": true
-                            }
-                          }
-                        ],
-                        "nextParams": [
-                          {
-                            "type": "Identifier",
-                            "name": "data"
-                          }
-                        ]
+                        "type": "Identifier",
+                        "name": "IO"
                       },
                       "property": {
                         "type": "Identifier",
-                        "name": "map"
+                        "name": "readFile"
                       }
                     },
                     "arguments": [
                       {
-                        "type": "ArrowFunctionExpression",
-                        "id": null,
-                        "params": [
-                          {
+                        "type": "MemberExpression",
+                        "computed": true,
+                        "object": {
+                          "type": "MemberExpression",
+                          "computed": false,
+                          "object": {
                             "type": "Identifier",
-                            "name": "data"
+                            "name": "process"
+                          },
+                          "property": {
+                            "type": "Identifier",
+                            "name": "argv",
+                            "isSubscript": false
                           }
-                        ],
-                        "body": {
-                          "type": "ArrayExpression",
-                          "elements": [
-                            {
-                              "type": "Identifier",
-                              "name": "data"
-                            }
-                          ]
                         },
-                        "generator": false,
-                        "expression": true
+                        "property": {
+                          "type": "Literal",
+                          "value": 2,
+                          "raw": "2",
+                          "sType": "number",
+                          "isSubscript": true
+                        }
                       }
                     ],
                     "nextParams": [
@@ -123,52 +83,61 @@
                       }
                     ],
                     "body": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "IO"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "writeFile"
-                        }
-                      },
-                      "arguments": [
+                      "type": "ArrayExpression",
+                      "elements": [
                         {
-                          "type": "MemberExpression",
-                          "computed": true,
-                          "object": {
+                          "type": "Identifier",
+                          "name": "data"
+                        },
+                        {
+                          "type": "CallExpression",
+                          "callee": {
                             "type": "MemberExpression",
                             "computed": false,
                             "object": {
                               "type": "Identifier",
-                              "name": "process"
+                              "name": "IO"
                             },
                             "property": {
                               "type": "Identifier",
-                              "name": "argv",
-                              "isSubscript": false
+                              "name": "writeFile"
                             }
                           },
-                          "property": {
-                            "type": "Literal",
-                            "value": 3,
-                            "raw": "3",
-                            "sType": "number",
-                            "isSubscript": true
-                          }
-                        },
-                        {
-                          "type": "Identifier",
-                          "name": "data"
+                          "arguments": [
+                            {
+                              "type": "MemberExpression",
+                              "computed": true,
+                              "object": {
+                                "type": "MemberExpression",
+                                "computed": false,
+                                "object": {
+                                  "type": "Identifier",
+                                  "name": "process"
+                                },
+                                "property": {
+                                  "type": "Identifier",
+                                  "name": "argv",
+                                  "isSubscript": false
+                                }
+                              },
+                              "property": {
+                                "type": "Literal",
+                                "value": 3,
+                                "raw": "3",
+                                "sType": "number",
+                                "isSubscript": true
+                              }
+                            },
+                            {
+                              "type": "Identifier",
+                              "name": "data"
+                            }
+                          ]
                         }
                       ]
                     },
                     "generator": false,
-                    "expression": false
+                    "expression": true
                   }
                 ],
                 "nextParams": [
@@ -187,12 +156,7 @@
               {
                 "type": "ArrowFunctionExpression",
                 "id": null,
-                "params": [
-                  {
-                    "type": "Identifier",
-                    "name": "data"
-                  }
-                ],
+                "params": [],
                 "body": {
                   "type": "ArrayExpression",
                   "elements": []

--- a/test/assert/ioLets.json
+++ b/test/assert/ioLets.json
@@ -45,575 +45,192 @@
                                     "type": "MemberExpression",
                                     "computed": false,
                                     "object": {
-                                      "type": "CallExpression",
-                                      "callee": {
-                                        "type": "MemberExpression",
-                                        "computed": false,
-                                        "object": {
-                                          "type": "CallExpression",
-                                          "callee": {
-                                            "type": "MemberExpression",
-                                            "computed": false,
-                                            "object": {
+                                      "type": "Identifier",
+                                      "name": "IO"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "getLine"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Literal",
+                                      "value": "Enter a number: ",
+                                      "raw": "Enter a number: ",
+                                      "sType": "string"
+                                    }
+                                  ],
+                                  "nextParams": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "a"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "b"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "c"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "d"
+                                    }
+                                  ]
+                                },
+                                "property": {
+                                  "type": "Identifier",
+                                  "name": "bind"
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "type": "ArrowFunctionExpression",
+                                  "id": null,
+                                  "params": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "a"
+                                    }
+                                  ],
+                                  "body": {
+                                    "type": "BlockStatement",
+                                    "body": [
+                                      {
+                                        "type": "VariableDeclaration",
+                                        "declarations": [
+                                          {
+                                            "type": "VariableDeclarator",
+                                            "id": {
+                                              "type": "Identifier",
+                                              "name": "b"
+                                            },
+                                            "init": {
                                               "type": "CallExpression",
                                               "callee": {
                                                 "type": "MemberExpression",
                                                 "computed": false,
                                                 "object": {
-                                                  "type": "CallExpression",
-                                                  "callee": {
-                                                    "type": "MemberExpression",
-                                                    "computed": false,
-                                                    "object": {
-                                                      "type": "CallExpression",
-                                                      "callee": {
-                                                        "type": "MemberExpression",
-                                                        "computed": false,
-                                                        "object": {
-                                                          "type": "CallExpression",
-                                                          "callee": {
-                                                            "type": "MemberExpression",
-                                                            "computed": false,
-                                                            "object": {
-                                                              "type": "CallExpression",
-                                                              "callee": {
-                                                                "type": "MemberExpression",
-                                                                "computed": false,
-                                                                "object": {
-                                                                  "type": "CallExpression",
-                                                                  "callee": {
-                                                                    "type": "MemberExpression",
-                                                                    "computed": false,
-                                                                    "object": {
-                                                                      "type": "Identifier",
-                                                                      "name": "IO"
-                                                                    },
-                                                                    "property": {
-                                                                      "type": "Identifier",
-                                                                      "name": "getLine"
-                                                                    }
-                                                                  },
-                                                                  "arguments": [
-                                                                    {
-                                                                      "type": "Literal",
-                                                                      "value": "Enter a number: ",
-                                                                      "raw": "Enter a number: ",
-                                                                      "sType": "string"
-                                                                    }
-                                                                  ],
-                                                                  "nextParams": [
-                                                                    {
-                                                                      "type": "Identifier",
-                                                                      "name": "a"
-                                                                    }
-                                                                  ]
-                                                                },
-                                                                "property": {
-                                                                  "type": "Identifier",
-                                                                  "name": "map"
-                                                                }
-                                                              },
-                                                              "arguments": [
-                                                                {
-                                                                  "type": "ArrowFunctionExpression",
-                                                                  "id": null,
-                                                                  "params": [
-                                                                    {
-                                                                      "type": "Identifier",
-                                                                      "name": "a"
-                                                                    }
-                                                                  ],
-                                                                  "body": {
-                                                                    "type": "ArrayExpression",
-                                                                    "elements": [
-                                                                      {
-                                                                        "type": "Identifier",
-                                                                        "name": "a"
-                                                                      }
-                                                                    ]
-                                                                  },
-                                                                  "generator": false,
-                                                                  "expression": true
-                                                                }
-                                                              ],
-                                                              "nextParams": [
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "a"
-                                                                }
-                                                              ]
-                                                            },
-                                                            "property": {
-                                                              "type": "Identifier",
-                                                              "name": "map"
-                                                            }
-                                                          },
-                                                          "arguments": [
-                                                            {
-                                                              "type": "ArrowFunctionExpression",
-                                                              "id": null,
-                                                              "params": [
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "a"
-                                                                }
-                                                              ],
-                                                              "body": {
-                                                                "type": "BlockStatement",
-                                                                "body": [
-                                                                  {
-                                                                    "type": "VariableDeclaration",
-                                                                    "declarations": [
-                                                                      {
-                                                                        "type": "VariableDeclarator",
-                                                                        "id": {
-                                                                          "type": "Identifier",
-                                                                          "name": "b"
-                                                                        },
-                                                                        "init": {
-                                                                          "type": "CallExpression",
-                                                                          "callee": {
-                                                                            "type": "MemberExpression",
-                                                                            "computed": false,
-                                                                            "object": {
-                                                                              "type": "Identifier",
-                                                                              "name": "Math"
-                                                                            },
-                                                                            "property": {
-                                                                              "type": "Identifier",
-                                                                              "name": "pow",
-                                                                              "isSubscript": false
-                                                                            }
-                                                                          },
-                                                                          "arguments": [
-                                                                            {
-                                                                              "type": "CallExpression",
-                                                                              "callee": {
-                                                                                "type": "Identifier",
-                                                                                "name": "parseInt"
-                                                                              },
-                                                                              "arguments": [
-                                                                                {
-                                                                                  "type": "Identifier",
-                                                                                  "name": "a"
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            {
-                                                                              "type": "Literal",
-                                                                              "value": 5,
-                                                                              "raw": "5",
-                                                                              "sType": "number"
-                                                                            }
-                                                                          ]
-                                                                        }
-                                                                      }
-                                                                    ],
-                                                                    "kind": "let"
-                                                                  },
-                                                                  {
-                                                                    "type": "VariableDeclaration",
-                                                                    "declarations": [
-                                                                      {
-                                                                        "type": "VariableDeclarator",
-                                                                        "id": {
-                                                                          "type": "Identifier",
-                                                                          "name": "c"
-                                                                        },
-                                                                        "init": {
-                                                                          "type": "BinaryExpression",
-                                                                          "operator": "+",
-                                                                          "sType": "number",
-                                                                          "left": {
-                                                                            "type": "Identifier",
-                                                                            "name": "b"
-                                                                          },
-                                                                          "right": {
-                                                                            "type": "Literal",
-                                                                            "value": 25,
-                                                                            "raw": "25",
-                                                                            "sType": "number"
-                                                                          }
-                                                                        }
-                                                                      }
-                                                                    ],
-                                                                    "kind": "let"
-                                                                  },
-                                                                  {
-                                                                    "type": "VariableDeclaration",
-                                                                    "declarations": [
-                                                                      {
-                                                                        "type": "VariableDeclarator",
-                                                                        "id": {
-                                                                          "type": "Identifier",
-                                                                          "name": "d"
-                                                                        },
-                                                                        "init": {
-                                                                          "type": "Literal",
-                                                                          "value": "some string val",
-                                                                          "raw": "some string val",
-                                                                          "sType": "string"
-                                                                        }
-                                                                      }
-                                                                    ],
-                                                                    "kind": "let"
-                                                                  },
-                                                                  {
-                                                                    "type": "ReturnStatement",
-                                                                    "argument": {
-                                                                      "type": "ArrayExpression",
-                                                                      "elements": [
-                                                                        {
-                                                                          "type": "Identifier",
-                                                                          "name": "a"
-                                                                        },
-                                                                        {
-                                                                          "type": "Identifier",
-                                                                          "name": "b"
-                                                                        },
-                                                                        {
-                                                                          "type": "Identifier",
-                                                                          "name": "c"
-                                                                        },
-                                                                        {
-                                                                          "type": "Identifier",
-                                                                          "name": "d"
-                                                                        }
-                                                                      ]
-                                                                    }
-                                                                  }
-                                                                ]
-                                                              },
-                                                              "generator": false,
-                                                              "expression": false
-                                                            }
-                                                          ],
-                                                          "nextParams": [
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "a"
-                                                            },
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "b"
-                                                            },
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "c"
-                                                            },
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "d"
-                                                            }
-                                                          ]
-                                                        },
-                                                        "property": {
-                                                          "type": "Identifier",
-                                                          "name": "bind"
-                                                        }
-                                                      },
-                                                      "arguments": [
-                                                        {
-                                                          "type": "ArrowFunctionExpression",
-                                                          "id": null,
-                                                          "params": [
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "a"
-                                                            },
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "b"
-                                                            },
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "c"
-                                                            },
-                                                            {
-                                                              "type": "Identifier",
-                                                              "name": "d"
-                                                            }
-                                                          ],
-                                                          "body": {
-                                                            "type": "CallExpression",
-                                                            "callee": {
-                                                              "type": "MemberExpression",
-                                                              "computed": false,
-                                                              "object": {
-                                                                "type": "Identifier",
-                                                                "name": "IO"
-                                                              },
-                                                              "property": {
-                                                                "type": "Identifier",
-                                                                "name": "putLine"
-                                                              }
-                                                            },
-                                                            "arguments": [
-                                                              {
-                                                                "type": "Identifier",
-                                                                "name": "a"
-                                                              },
-                                                              {
-                                                                "type": "Identifier",
-                                                                "name": "b"
-                                                              },
-                                                              {
-                                                                "type": "Identifier",
-                                                                "name": "c"
-                                                              },
-                                                              {
-                                                                "type": "Identifier",
-                                                                "name": "d"
-                                                              }
-                                                            ]
-                                                          },
-                                                          "generator": false,
-                                                          "expression": false
-                                                        }
-                                                      ],
-                                                      "nextParams": [
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "a"
-                                                        },
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "b"
-                                                        },
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "c"
-                                                        },
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "d"
-                                                        }
-                                                      ]
-                                                    },
-                                                    "property": {
-                                                      "type": "Identifier",
-                                                      "name": "map"
-                                                    }
-                                                  },
-                                                  "arguments": [
-                                                    {
-                                                      "type": "ArrowFunctionExpression",
-                                                      "id": null,
-                                                      "params": [
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "a"
-                                                        },
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "b"
-                                                        },
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "c"
-                                                        },
-                                                        {
-                                                          "type": "Identifier",
-                                                          "name": "d"
-                                                        }
-                                                      ],
-                                                      "body": {
-                                                        "type": "BlockStatement",
-                                                        "body": [
-                                                          {
-                                                            "type": "VariableDeclaration",
-                                                            "declarations": [
-                                                              {
-                                                                "type": "VariableDeclarator",
-                                                                "id": {
-                                                                  "type": "Identifier",
-                                                                  "name": "obj"
-                                                                },
-                                                                "init": {
-                                                                  "type": "ObjectExpression",
-                                                                  "properties": []
-                                                                }
-                                                              }
-                                                            ],
-                                                            "kind": "let"
-                                                          },
-                                                          {
-                                                            "type": "VariableDeclaration",
-                                                            "declarations": [
-                                                              {
-                                                                "type": "VariableDeclarator",
-                                                                "id": {
-                                                                  "type": "Identifier",
-                                                                  "name": "val1"
-                                                                },
-                                                                "init": {
-                                                                  "type": "Literal",
-                                                                  "value": "string",
-                                                                  "raw": "string",
-                                                                  "sType": "string"
-                                                                }
-                                                              }
-                                                            ],
-                                                            "kind": "let"
-                                                          },
-                                                          {
-                                                            "type": "ReturnStatement",
-                                                            "argument": {
-                                                              "type": "ArrayExpression",
-                                                              "elements": [
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "a"
-                                                                },
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "b"
-                                                                },
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "c"
-                                                                },
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "d"
-                                                                },
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "obj"
-                                                                },
-                                                                {
-                                                                  "type": "Identifier",
-                                                                  "name": "val1"
-                                                                }
-                                                              ]
-                                                            }
-                                                          }
-                                                        ]
-                                                      },
-                                                      "generator": false,
-                                                      "expression": false
-                                                    }
-                                                  ],
-                                                  "nextParams": [
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "a"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "b"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "c"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "d"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "obj"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "val1"
-                                                    }
-                                                  ]
+                                                  "type": "Identifier",
+                                                  "name": "Math"
                                                 },
                                                 "property": {
                                                   "type": "Identifier",
-                                                  "name": "bind"
+                                                  "name": "pow",
+                                                  "isSubscript": false
                                                 }
                                               },
                                               "arguments": [
                                                 {
-                                                  "type": "ArrowFunctionExpression",
-                                                  "id": null,
-                                                  "params": [
+                                                  "type": "CallExpression",
+                                                  "callee": {
+                                                    "type": "Identifier",
+                                                    "name": "parseInt"
+                                                  },
+                                                  "arguments": [
                                                     {
                                                       "type": "Identifier",
                                                       "name": "a"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "b"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "c"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "d"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "obj"
-                                                    },
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "val1"
                                                     }
-                                                  ],
-                                                  "body": {
-                                                    "type": "CallExpression",
-                                                    "callee": {
-                                                      "type": "MemberExpression",
-                                                      "computed": false,
-                                                      "object": {
-                                                        "type": "Identifier",
-                                                        "name": "IO"
-                                                      },
-                                                      "property": {
-                                                        "type": "Identifier",
-                                                        "name": "getLine"
-                                                      }
-                                                    },
-                                                    "arguments": [
-                                                      {
-                                                        "type": "Literal",
-                                                        "value": "enter number",
-                                                        "raw": "enter number",
-                                                        "sType": "string"
-                                                      }
-                                                    ],
-                                                    "nextParams": [
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "a"
-                                                      },
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "b"
-                                                      },
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "c"
-                                                      },
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "d"
-                                                      },
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "obj"
-                                                      },
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "val1"
-                                                      },
-                                                      {
-                                                        "type": "Identifier",
-                                                        "name": "val2"
-                                                      }
-                                                    ]
-                                                  },
-                                                  "generator": false,
-                                                  "expression": true
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "Literal",
+                                                  "value": 5,
+                                                  "raw": "5",
+                                                  "sType": "number"
                                                 }
-                                              ],
-                                              "nextParams": [
+                                              ]
+                                            }
+                                          }
+                                        ],
+                                        "kind": "let"
+                                      },
+                                      {
+                                        "type": "VariableDeclaration",
+                                        "declarations": [
+                                          {
+                                            "type": "VariableDeclarator",
+                                            "id": {
+                                              "type": "Identifier",
+                                              "name": "c"
+                                            },
+                                            "init": {
+                                              "type": "BinaryExpression",
+                                              "operator": "+",
+                                              "sType": "number",
+                                              "left": {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                              },
+                                              "right": {
+                                                "type": "Literal",
+                                                "value": 25,
+                                                "raw": "25",
+                                                "sType": "number"
+                                              }
+                                            }
+                                          }
+                                        ],
+                                        "kind": "let"
+                                      },
+                                      {
+                                        "type": "VariableDeclaration",
+                                        "declarations": [
+                                          {
+                                            "type": "VariableDeclarator",
+                                            "id": {
+                                              "type": "Identifier",
+                                              "name": "d"
+                                            },
+                                            "init": {
+                                              "type": "Literal",
+                                              "value": "some string val",
+                                              "raw": "some string val",
+                                              "sType": "string"
+                                            }
+                                          }
+                                        ],
+                                        "kind": "let"
+                                      },
+                                      {
+                                        "type": "ReturnStatement",
+                                        "argument": {
+                                          "type": "ArrayExpression",
+                                          "elements": [
+                                            {
+                                              "type": "Identifier",
+                                              "name": "a"
+                                            },
+                                            {
+                                              "type": "Identifier",
+                                              "name": "b"
+                                            },
+                                            {
+                                              "type": "Identifier",
+                                              "name": "c"
+                                            },
+                                            {
+                                              "type": "Identifier",
+                                              "name": "d"
+                                            },
+                                            {
+                                              "type": "CallExpression",
+                                              "callee": {
+                                                "type": "MemberExpression",
+                                                "computed": false,
+                                                "object": {
+                                                  "type": "Identifier",
+                                                  "name": "IO"
+                                                },
+                                                "property": {
+                                                  "type": "Identifier",
+                                                  "name": "putLine"
+                                                }
+                                              },
+                                              "arguments": [
                                                 {
                                                   "type": "Identifier",
                                                   "name": "a"
@@ -629,95 +246,152 @@
                                                 {
                                                   "type": "Identifier",
                                                   "name": "d"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "obj"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "val1"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "val2"
                                                 }
                                               ]
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "generator": false,
+                                  "expression": false
+                                }
+                              ],
+                              "nextParams": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "a"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "b"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "c"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "d"
+                                }
+                              ]
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "name": "bind"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "ArrowFunctionExpression",
+                              "id": null,
+                              "params": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "a"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "b"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "c"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "name": "d"
+                                }
+                              ],
+                              "body": {
+                                "type": "BlockStatement",
+                                "body": [
+                                  {
+                                    "type": "VariableDeclaration",
+                                    "declarations": [
+                                      {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                          "type": "Identifier",
+                                          "name": "obj"
+                                        },
+                                        "init": {
+                                          "type": "ObjectExpression",
+                                          "properties": []
+                                        }
+                                      }
+                                    ],
+                                    "kind": "let"
+                                  },
+                                  {
+                                    "type": "VariableDeclaration",
+                                    "declarations": [
+                                      {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                          "type": "Identifier",
+                                          "name": "val1"
+                                        },
+                                        "init": {
+                                          "type": "Literal",
+                                          "value": "string",
+                                          "raw": "string",
+                                          "sType": "string"
+                                        }
+                                      }
+                                    ],
+                                    "kind": "let"
+                                  },
+                                  {
+                                    "type": "ReturnStatement",
+                                    "argument": {
+                                      "type": "ArrayExpression",
+                                      "elements": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "a"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "b"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "c"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "d"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "obj"
+                                        },
+                                        {
+                                          "type": "Identifier",
+                                          "name": "val1"
+                                        },
+                                        {
+                                          "type": "CallExpression",
+                                          "callee": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                              "type": "Identifier",
+                                              "name": "IO"
                                             },
                                             "property": {
                                               "type": "Identifier",
-                                              "name": "map"
+                                              "name": "getLine"
                                             }
                                           },
                                           "arguments": [
                                             {
-                                              "type": "ArrowFunctionExpression",
-                                              "id": null,
-                                              "params": [
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "a"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "b"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "c"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "d"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "obj"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "val1"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "val2"
-                                                }
-                                              ],
-                                              "body": {
-                                                "type": "ArrayExpression",
-                                                "elements": [
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "a"
-                                                  },
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "b"
-                                                  },
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "c"
-                                                  },
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "d"
-                                                  },
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "obj"
-                                                  },
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "val1"
-                                                  },
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "val2"
-                                                  }
-                                                ]
-                                              },
-                                              "generator": false,
-                                              "expression": true
+                                              "type": "Literal",
+                                              "value": "enter number",
+                                              "raw": "enter number",
+                                              "sType": "string"
                                             }
                                           ],
                                           "nextParams": [
@@ -750,653 +424,6 @@
                                               "name": "val2"
                                             }
                                           ]
-                                        },
-                                        "property": {
-                                          "type": "Identifier",
-                                          "name": "maybeTrue"
-                                        }
-                                      },
-                                      "arguments": [
-                                        {
-                                          "type": "ArrowFunctionExpression",
-                                          "id": null,
-                                          "params": [
-                                            {
-                                              "type": "Identifier",
-                                              "name": "a"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "b"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "c"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "d"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "obj"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "val1"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "val2"
-                                            }
-                                          ],
-                                          "body": {
-                                            "type": "BinaryExpression",
-                                            "operator": "!==",
-                                            "sType": "bool",
-                                            "left": {
-                                              "type": "BinaryExpression",
-                                              "operator": "%",
-                                              "sType": "number",
-                                              "left": {
-                                                "type": "CallExpression",
-                                                "callee": {
-                                                  "type": "Identifier",
-                                                  "name": "parseInt"
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "type": "Identifier",
-                                                    "name": "val2"
-                                                  }
-                                                ]
-                                              },
-                                              "right": {
-                                                "type": "Literal",
-                                                "value": 2,
-                                                "raw": "2",
-                                                "sType": "number"
-                                              }
-                                            },
-                                            "right": {
-                                              "type": "Literal",
-                                              "value": 0,
-                                              "raw": "0",
-                                              "sType": "number"
-                                            }
-                                          },
-                                          "generator": false,
-                                          "expression": true
-                                        },
-                                        {
-                                          "type": "ArrowFunctionExpression",
-                                          "id": null,
-                                          "params": [
-                                            {
-                                              "type": "Identifier",
-                                              "name": "a"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "b"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "c"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "d"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "obj"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "val1"
-                                            },
-                                            {
-                                              "type": "Identifier",
-                                              "name": "val2"
-                                            }
-                                          ],
-                                          "body": {
-                                            "type": "CallExpression",
-                                            "callee": {
-                                              "type": "MemberExpression",
-                                              "computed": false,
-                                              "object": {
-                                                "type": "CallExpression",
-                                                "callee": {
-                                                  "type": "MemberExpression",
-                                                  "computed": false,
-                                                  "object": {
-                                                    "type": "Identifier",
-                                                    "name": "IO"
-                                                  },
-                                                  "property": {
-                                                    "type": "Identifier",
-                                                    "name": "putLine"
-                                                  }
-                                                },
-                                                "arguments": [
-                                                  {
-                                                    "type": "Literal",
-                                                    "value": "not even",
-                                                    "raw": "not even",
-                                                    "sType": "string"
-                                                  }
-                                                ],
-                                                "nextParams": []
-                                              },
-                                              "property": {
-                                                "type": "Identifier",
-                                                "name": "then"
-                                              }
-                                            },
-                                            "arguments": [
-                                              {
-                                                "type": "ArrowFunctionExpression",
-                                                "id": null,
-                                                "params": [],
-                                                "body": {
-                                                  "type": "Literal",
-                                                  "value": null,
-                                                  "raw": "null"
-                                                },
-                                                "generator": false,
-                                                "expression": true
-                                              }
-                                            ]
-                                          },
-                                          "generator": false,
-                                          "expression": true
-                                        }
-                                      ],
-                                      "nextParams": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "a"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "b"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "c"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "d"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "obj"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "val1"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "val2"
-                                        }
-                                      ]
-                                    },
-                                    "property": {
-                                      "type": "Identifier",
-                                      "name": "map"
-                                    }
-                                  },
-                                  "arguments": [
-                                    {
-                                      "type": "ArrowFunctionExpression",
-                                      "id": null,
-                                      "params": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "a"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "b"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "c"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "d"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "obj"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "val1"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "val2"
-                                        }
-                                      ],
-                                      "body": {
-                                        "type": "BlockStatement",
-                                        "body": [
-                                          {
-                                            "type": "ExpressionStatement",
-                                            "expression": {
-                                              "type": "CallExpression",
-                                              "callee": {
-                                                "type": "MemberExpression",
-                                                "computed": false,
-                                                "object": {
-                                                  "type": "Identifier",
-                                                  "name": "Object"
-                                                },
-                                                "property": {
-                                                  "type": "Identifier",
-                                                  "name": "defineProperty"
-                                                }
-                                              },
-                                              "arguments": [
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "obj"
-                                                },
-                                                {
-                                                  "type": "Literal",
-                                                  "value": "key",
-                                                  "raw": "key",
-                                                  "sType": "string"
-                                                },
-                                                {
-                                                  "type": "ObjectExpression",
-                                                  "properties": [
-                                                    {
-                                                      "type": "Property",
-                                                      "key": {
-                                                        "type": "Identifier",
-                                                        "name": "value"
-                                                      },
-                                                      "computed": false,
-                                                      "value": {
-                                                        "type": "Literal",
-                                                        "value": 123,
-                                                        "raw": "123",
-                                                        "sType": "number"
-                                                      },
-                                                      "kind": "init",
-                                                      "method": false,
-                                                      "shorthand": false
-                                                    },
-                                                    {
-                                                      "type": "Property",
-                                                      "key": {
-                                                        "type": "Identifier",
-                                                        "name": "enumerable"
-                                                      },
-                                                      "computed": false,
-                                                      "value": {
-                                                        "type": "Literal",
-                                                        "value": true,
-                                                        "raw": "true"
-                                                      },
-                                                      "kind": "init",
-                                                      "method": false,
-                                                      "shorthand": false
-                                                    },
-                                                    {
-                                                      "type": "Property",
-                                                      "key": {
-                                                        "type": "Identifier",
-                                                        "name": "writable"
-                                                      },
-                                                      "computed": false,
-                                                      "value": {
-                                                        "type": "Literal",
-                                                        "value": true,
-                                                        "raw": "true"
-                                                      },
-                                                      "kind": "init",
-                                                      "method": false,
-                                                      "shorthand": false
-                                                    },
-                                                    {
-                                                      "type": "Property",
-                                                      "key": {
-                                                        "type": "Identifier",
-                                                        "name": "configurable"
-                                                      },
-                                                      "computed": false,
-                                                      "value": {
-                                                        "type": "Literal",
-                                                        "value": true,
-                                                        "raw": "true"
-                                                      },
-                                                      "kind": "init",
-                                                      "method": false,
-                                                      "shorthand": false
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "type": "VariableDeclaration",
-                                            "declarations": [
-                                              {
-                                                "type": "VariableDeclarator",
-                                                "id": {
-                                                  "type": "Identifier",
-                                                  "name": "returnVal"
-                                                },
-                                                "init": {
-                                                  "type": "CallExpression",
-                                                  "callee": {
-                                                    "type": "Identifier",
-                                                    "name": "parseInt"
-                                                  },
-                                                  "arguments": [
-                                                    {
-                                                      "type": "Identifier",
-                                                      "name": "val2"
-                                                    }
-                                                  ]
-                                                }
-                                              }
-                                            ],
-                                            "kind": "let"
-                                          },
-                                          {
-                                            "type": "ReturnStatement",
-                                            "argument": {
-                                              "type": "ArrayExpression",
-                                              "elements": [
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "a"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "b"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "c"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "d"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "obj"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "val1"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "val2"
-                                                },
-                                                {
-                                                  "type": "Identifier",
-                                                  "name": "returnVal"
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      "generator": false,
-                                      "expression": false
-                                    }
-                                  ],
-                                  "nextParams": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "a"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "b"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "c"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "d"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "obj"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "val1"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "val2"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "returnVal"
-                                    }
-                                  ]
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "name": "bind"
-                                }
-                              },
-                              "arguments": [
-                                {
-                                  "type": "ArrowFunctionExpression",
-                                  "id": null,
-                                  "params": [
-                                    {
-                                      "type": "Identifier",
-                                      "name": "a"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "b"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "c"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "d"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "obj"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "val1"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "val2"
-                                    },
-                                    {
-                                      "type": "Identifier",
-                                      "name": "returnVal"
-                                    }
-                                  ],
-                                  "body": {
-                                    "type": "CallExpression",
-                                    "callee": {
-                                      "type": "MemberExpression",
-                                      "computed": false,
-                                      "object": {
-                                        "type": "Identifier",
-                                        "name": "IO"
-                                      },
-                                      "property": {
-                                        "type": "Identifier",
-                                        "name": "putLine"
-                                      }
-                                    },
-                                    "arguments": [
-                                      {
-                                        "type": "Identifier",
-                                        "name": "obj"
-                                      }
-                                    ]
-                                  },
-                                  "generator": false,
-                                  "expression": false
-                                }
-                              ],
-                              "nextParams": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "a"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "b"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "c"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "d"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "obj"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "val1"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "val2"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "returnVal"
-                                }
-                              ]
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "name": "map"
-                            }
-                          },
-                          "arguments": [
-                            {
-                              "type": "ArrowFunctionExpression",
-                              "id": null,
-                              "params": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "a"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "b"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "c"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "d"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "obj"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "val1"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "val2"
-                                },
-                                {
-                                  "type": "Identifier",
-                                  "name": "returnVal"
-                                }
-                              ],
-                              "body": {
-                                "type": "BlockStatement",
-                                "body": [
-                                  {
-                                    "type": "UnaryExpression",
-                                    "operator": "delete",
-                                    "argument": {
-                                      "type": "MemberExpression",
-                                      "computed": false,
-                                      "object": {
-                                        "type": "Identifier",
-                                        "name": "obj"
-                                      },
-                                      "property": {
-                                        "type": "Identifier",
-                                        "name": "key",
-                                        "isSubscript": false
-                                      }
-                                    },
-                                    "prefix": true
-                                  },
-                                  {
-                                    "type": "ReturnStatement",
-                                    "argument": {
-                                      "type": "ArrayExpression",
-                                      "elements": [
-                                        {
-                                          "type": "Identifier",
-                                          "name": "a"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "b"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "c"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "d"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "obj"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "val1"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "val2"
-                                        },
-                                        {
-                                          "type": "Identifier",
-                                          "name": "returnVal"
                                         }
                                       ]
                                     }
@@ -1479,36 +506,305 @@
                             {
                               "type": "Identifier",
                               "name": "val2"
-                            },
-                            {
-                              "type": "Identifier",
-                              "name": "returnVal"
                             }
                           ],
                           "body": {
-                            "type": "CallExpression",
-                            "callee": {
-                              "type": "MemberExpression",
-                              "computed": false,
-                              "object": {
-                                "type": "Identifier",
-                                "name": "IO"
-                              },
-                              "property": {
-                                "type": "Identifier",
-                                "name": "putLine"
-                              }
-                            },
-                            "arguments": [
+                            "type": "BlockStatement",
+                            "body": [
                               {
-                                "type": "Identifier",
-                                "name": "obj"
+                                "type": "IfStatement",
+                                "test": {
+                                  "type": "BinaryExpression",
+                                  "operator": "===",
+                                  "sType": "bool",
+                                  "left": {
+                                    "type": "BinaryExpression",
+                                    "operator": "!==",
+                                    "sType": "bool",
+                                    "left": {
+                                      "type": "BinaryExpression",
+                                      "operator": "%",
+                                      "sType": "number",
+                                      "left": {
+                                        "type": "CallExpression",
+                                        "callee": {
+                                          "type": "Identifier",
+                                          "name": "parseInt"
+                                        },
+                                        "arguments": [
+                                          {
+                                            "type": "Identifier",
+                                            "name": "val2"
+                                          }
+                                        ]
+                                      },
+                                      "right": {
+                                        "type": "Literal",
+                                        "value": 2,
+                                        "raw": "2",
+                                        "sType": "number"
+                                      }
+                                    },
+                                    "right": {
+                                      "type": "Literal",
+                                      "value": 0,
+                                      "raw": "0",
+                                      "sType": "number"
+                                    }
+                                  },
+                                  "right": {
+                                    "type": "Literal",
+                                    "value": true,
+                                    "raw": "true",
+                                    "sType": "bool"
+                                  }
+                                },
+                                "consequent": {
+                                  "type": "BlockStatement",
+                                  "body": [
+                                    {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "MemberExpression",
+                                        "computed": false,
+                                        "object": {
+                                          "type": "CallExpression",
+                                          "callee": {
+                                            "type": "MemberExpression",
+                                            "computed": false,
+                                            "object": {
+                                              "type": "Identifier",
+                                              "name": "IO"
+                                            },
+                                            "property": {
+                                              "type": "Identifier",
+                                              "name": "putLine"
+                                            }
+                                          },
+                                          "arguments": [
+                                            {
+                                              "type": "Literal",
+                                              "value": "not even",
+                                              "raw": "not even",
+                                              "sType": "string"
+                                            }
+                                          ],
+                                          "nextParams": []
+                                        },
+                                        "property": {
+                                          "type": "Identifier",
+                                          "name": "then"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "ArrowFunctionExpression",
+                                          "id": null,
+                                          "params": [],
+                                          "body": {
+                                            "type": "Literal",
+                                            "value": null,
+                                            "raw": "null"
+                                          },
+                                          "generator": false,
+                                          "expression": true
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "ReturnStatement",
+                                      "argument": null
+                                    }
+                                  ]
+                                },
+                                "alternate": null
                               },
                               {
-                                "type": "Literal",
-                                "value": "obj in this function",
-                                "raw": "obj in this function",
-                                "sType": "string"
+                                "type": "ExpressionStatement",
+                                "expression": {
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "name": "Object"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "defineProperty"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "obj"
+                                    },
+                                    {
+                                      "type": "Literal",
+                                      "value": "key",
+                                      "raw": "key",
+                                      "sType": "string"
+                                    },
+                                    {
+                                      "type": "ObjectExpression",
+                                      "properties": [
+                                        {
+                                          "type": "Property",
+                                          "key": {
+                                            "type": "Identifier",
+                                            "name": "value"
+                                          },
+                                          "computed": false,
+                                          "value": {
+                                            "type": "Literal",
+                                            "value": 123,
+                                            "raw": "123",
+                                            "sType": "number"
+                                          },
+                                          "kind": "init",
+                                          "method": false,
+                                          "shorthand": false
+                                        },
+                                        {
+                                          "type": "Property",
+                                          "key": {
+                                            "type": "Identifier",
+                                            "name": "enumerable"
+                                          },
+                                          "computed": false,
+                                          "value": {
+                                            "type": "Literal",
+                                            "value": true,
+                                            "raw": "true"
+                                          },
+                                          "kind": "init",
+                                          "method": false,
+                                          "shorthand": false
+                                        },
+                                        {
+                                          "type": "Property",
+                                          "key": {
+                                            "type": "Identifier",
+                                            "name": "writable"
+                                          },
+                                          "computed": false,
+                                          "value": {
+                                            "type": "Literal",
+                                            "value": true,
+                                            "raw": "true"
+                                          },
+                                          "kind": "init",
+                                          "method": false,
+                                          "shorthand": false
+                                        },
+                                        {
+                                          "type": "Property",
+                                          "key": {
+                                            "type": "Identifier",
+                                            "name": "configurable"
+                                          },
+                                          "computed": false,
+                                          "value": {
+                                            "type": "Literal",
+                                            "value": true,
+                                            "raw": "true"
+                                          },
+                                          "kind": "init",
+                                          "method": false,
+                                          "shorthand": false
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "VariableDeclaration",
+                                "declarations": [
+                                  {
+                                    "type": "VariableDeclarator",
+                                    "id": {
+                                      "type": "Identifier",
+                                      "name": "returnVal"
+                                    },
+                                    "init": {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "Identifier",
+                                        "name": "parseInt"
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "val2"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "kind": "let"
+                              },
+                              {
+                                "type": "ReturnStatement",
+                                "argument": {
+                                  "type": "ArrayExpression",
+                                  "elements": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "a"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "b"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "c"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "d"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "obj"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "val1"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "val2"
+                                    },
+                                    {
+                                      "type": "Identifier",
+                                      "name": "returnVal"
+                                    },
+                                    {
+                                      "type": "CallExpression",
+                                      "callee": {
+                                        "type": "MemberExpression",
+                                        "computed": false,
+                                        "object": {
+                                          "type": "Identifier",
+                                          "name": "IO"
+                                        },
+                                        "property": {
+                                          "type": "Identifier",
+                                          "name": "putLine"
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Identifier",
+                                          "name": "obj"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
                               }
                             ]
                           },
@@ -1553,7 +849,7 @@
                     },
                     "property": {
                       "type": "Identifier",
-                      "name": "map"
+                      "name": "bind"
                     }
                   },
                   "arguments": [
@@ -1598,39 +894,22 @@
                         "type": "BlockStatement",
                         "body": [
                           {
-                            "type": "VariableDeclaration",
-                            "declarations": [
-                              {
-                                "type": "VariableDeclarator",
-                                "id": {
-                                  "type": "Identifier",
-                                  "name": "vals"
-                                },
-                                "init": {
-                                  "type": "BinaryExpression",
-                                  "operator": "+",
-                                  "sType": "number",
-                                  "left": {
-                                    "type": "BinaryExpression",
-                                    "operator": "+",
-                                    "sType": "number",
-                                    "left": {
-                                      "type": "Identifier",
-                                      "name": "val2"
-                                    },
-                                    "right": {
-                                      "type": "Identifier",
-                                      "name": "b"
-                                    }
-                                  },
-                                  "right": {
-                                    "type": "Identifier",
-                                    "name": "c"
-                                  }
-                                }
+                            "type": "UnaryExpression",
+                            "operator": "delete",
+                            "argument": {
+                              "type": "MemberExpression",
+                              "computed": false,
+                              "object": {
+                                "type": "Identifier",
+                                "name": "obj"
+                              },
+                              "property": {
+                                "type": "Identifier",
+                                "name": "key",
+                                "isSubscript": false
                               }
-                            ],
-                            "kind": "let"
+                            },
+                            "prefix": true
                           },
                           {
                             "type": "ReturnStatement",
@@ -1670,8 +949,31 @@
                                   "name": "returnVal"
                                 },
                                 {
-                                  "type": "Identifier",
-                                  "name": "vals"
+                                  "type": "CallExpression",
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "computed": false,
+                                    "object": {
+                                      "type": "Identifier",
+                                      "name": "IO"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "name": "putLine"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Identifier",
+                                      "name": "obj"
+                                    },
+                                    {
+                                      "type": "Literal",
+                                      "value": "obj in this function",
+                                      "raw": "obj in this function",
+                                      "sType": "string"
+                                    }
+                                  ]
                                 }
                               ]
                             }
@@ -1714,10 +1016,6 @@
                     {
                       "type": "Identifier",
                       "name": "returnVal"
-                    },
-                    {
-                      "type": "Identifier",
-                      "name": "vals"
                     }
                   ],
                   "returnVals": [
@@ -1772,27 +1070,66 @@
                     {
                       "type": "Identifier",
                       "name": "returnVal"
-                    },
-                    {
-                      "type": "Identifier",
-                      "name": "vals"
                     }
                   ],
                   "body": {
-                    "type": "ArrayExpression",
-                    "elements": [
+                    "type": "BlockStatement",
+                    "body": [
                       {
-                        "type": "Identifier",
-                        "name": "returnVal"
+                        "type": "VariableDeclaration",
+                        "declarations": [
+                          {
+                            "type": "VariableDeclarator",
+                            "id": {
+                              "type": "Identifier",
+                              "name": "vals"
+                            },
+                            "init": {
+                              "type": "BinaryExpression",
+                              "operator": "+",
+                              "sType": "number",
+                              "left": {
+                                "type": "BinaryExpression",
+                                "operator": "+",
+                                "sType": "number",
+                                "left": {
+                                  "type": "Identifier",
+                                  "name": "val2"
+                                },
+                                "right": {
+                                  "type": "Identifier",
+                                  "name": "b"
+                                }
+                              },
+                              "right": {
+                                "type": "Identifier",
+                                "name": "c"
+                              }
+                            }
+                          }
+                        ],
+                        "kind": "let"
                       },
                       {
-                        "type": "Identifier",
-                        "name": "obj"
+                        "type": "ReturnStatement",
+                        "argument": {
+                          "type": "ArrayExpression",
+                          "elements": [
+                            {
+                              "type": "Identifier",
+                              "name": "returnVal"
+                            },
+                            {
+                              "type": "Identifier",
+                              "name": "obj"
+                            }
+                          ]
+                        }
                       }
                     ]
                   },
                   "generator": false,
-                  "expression": true
+                  "expression": false
                 }
               ],
               "nextParams": [
@@ -1827,10 +1164,6 @@
                 {
                   "type": "Identifier",
                   "name": "returnVal"
-                },
-                {
-                  "type": "Identifier",
-                  "name": "vals"
                 }
               ]
             },
@@ -1899,20 +1232,8 @@
                       }
                     ],
                     "body": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "IO"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "putLine"
-                        }
-                      },
-                      "arguments": [
+                      "type": "ArrayExpression",
+                      "elements": [
                         {
                           "type": "Identifier",
                           "name": "val"
@@ -1920,11 +1241,36 @@
                         {
                           "type": "Identifier",
                           "name": "obj"
+                        },
+                        {
+                          "type": "CallExpression",
+                          "callee": {
+                            "type": "MemberExpression",
+                            "computed": false,
+                            "object": {
+                              "type": "Identifier",
+                              "name": "IO"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "name": "putLine"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "Identifier",
+                              "name": "val"
+                            },
+                            {
+                              "type": "Identifier",
+                              "name": "obj"
+                            }
+                          ]
                         }
                       ]
                     },
                     "generator": false,
-                    "expression": false
+                    "expression": true
                   }
                 ],
                 "nextParams": [
@@ -1947,16 +1293,7 @@
               {
                 "type": "ArrowFunctionExpression",
                 "id": null,
-                "params": [
-                  {
-                    "type": "Identifier",
-                    "name": "val"
-                  },
-                  {
-                    "type": "Identifier",
-                    "name": "obj"
-                  }
-                ],
+                "params": [],
                 "body": {
                   "type": "ArrayExpression",
                   "elements": []

--- a/test/assert/ioTest.json
+++ b/test/assert/ioTest.json
@@ -25,60 +25,20 @@
                     "type": "MemberExpression",
                     "computed": false,
                     "object": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "IO"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "getLine"
-                        }
-                      },
-                      "arguments": [
-                        {
-                          "type": "Literal",
-                          "value": "enter some value",
-                          "raw": "enter some value",
-                          "sType": "string"
-                        }
-                      ],
-                      "nextParams": [
-                        {
-                          "type": "Identifier",
-                          "name": "a"
-                        }
-                      ]
+                      "type": "Identifier",
+                      "name": "IO"
                     },
                     "property": {
                       "type": "Identifier",
-                      "name": "map"
+                      "name": "getLine"
                     }
                   },
                   "arguments": [
                     {
-                      "type": "ArrowFunctionExpression",
-                      "id": null,
-                      "params": [
-                        {
-                          "type": "Identifier",
-                          "name": "a"
-                        }
-                      ],
-                      "body": {
-                        "type": "ArrayExpression",
-                        "elements": [
-                          {
-                            "type": "Identifier",
-                            "name": "a"
-                          }
-                        ]
-                      },
-                      "generator": false,
-                      "expression": true
+                      "type": "Literal",
+                      "value": "enter some value",
+                      "raw": "enter some value",
+                      "sType": "string"
                     }
                   ],
                   "nextParams": [
@@ -161,60 +121,20 @@
                     "type": "MemberExpression",
                     "computed": false,
                     "object": {
-                      "type": "CallExpression",
-                      "callee": {
-                        "type": "MemberExpression",
-                        "computed": false,
-                        "object": {
-                          "type": "Identifier",
-                          "name": "IO"
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "readFile"
-                        }
-                      },
-                      "arguments": [
-                        {
-                          "type": "Literal",
-                          "value": "basicAssertion.json",
-                          "raw": "basicAssertion.json",
-                          "sType": "string"
-                        }
-                      ],
-                      "nextParams": [
-                        {
-                          "type": "Identifier",
-                          "name": "c"
-                        }
-                      ]
+                      "type": "Identifier",
+                      "name": "IO"
                     },
                     "property": {
                       "type": "Identifier",
-                      "name": "map"
+                      "name": "readFile"
                     }
                   },
                   "arguments": [
                     {
-                      "type": "ArrowFunctionExpression",
-                      "id": null,
-                      "params": [
-                        {
-                          "type": "Identifier",
-                          "name": "c"
-                        }
-                      ],
-                      "body": {
-                        "type": "ArrayExpression",
-                        "elements": [
-                          {
-                            "type": "Identifier",
-                            "name": "c"
-                          }
-                        ]
-                      },
-                      "generator": false,
-                      "expression": true
+                      "type": "Literal",
+                      "value": "basicAssertion.json",
+                      "raw": "basicAssertion.json",
+                      "sType": "string"
                     }
                   ],
                   "nextParams": [
@@ -349,90 +269,10 @@
                       "object": {
                         "type": "CallExpression",
                         "callee": {
-                          "type": "MemberExpression",
-                          "computed": false,
-                          "object": {
-                            "type": "CallExpression",
-                            "callee": {
-                              "type": "MemberExpression",
-                              "computed": false,
-                              "object": {
-                                "type": "CallExpression",
-                                "callee": {
-                                  "type": "Identifier",
-                                  "name": "sum"
-                                },
-                                "arguments": [],
-                                "nextParams": [
-                                  {
-                                    "type": "Identifier",
-                                    "name": "c"
-                                  }
-                                ]
-                              },
-                              "property": {
-                                "type": "Identifier",
-                                "name": "bind"
-                              }
-                            },
-                            "arguments": [
-                              {
-                                "type": "ArrowFunctionExpression",
-                                "id": null,
-                                "params": [
-                                  {
-                                    "type": "Identifier",
-                                    "name": "c"
-                                  }
-                                ],
-                                "body": {
-                                  "type": "CallExpression",
-                                  "callee": {
-                                    "type": "Identifier",
-                                    "name": "compute",
-                                    "nextParams": []
-                                  },
-                                  "arguments": []
-                                },
-                                "generator": false,
-                                "expression": true
-                              }
-                            ],
-                            "nextParams": [
-                              {
-                                "type": "Identifier",
-                                "name": "c"
-                              }
-                            ]
-                          },
-                          "property": {
-                            "type": "Identifier",
-                            "name": "map"
-                          }
+                          "type": "Identifier",
+                          "name": "sum"
                         },
-                        "arguments": [
-                          {
-                            "type": "ArrowFunctionExpression",
-                            "id": null,
-                            "params": [
-                              {
-                                "type": "Identifier",
-                                "name": "c"
-                              }
-                            ],
-                            "body": {
-                              "type": "ArrayExpression",
-                              "elements": [
-                                {
-                                  "type": "Identifier",
-                                  "name": "c"
-                                }
-                              ]
-                            },
-                            "generator": false,
-                            "expression": true
-                          }
-                        ],
+                        "arguments": [],
                         "nextParams": [
                           {
                             "type": "Identifier",
@@ -456,12 +296,18 @@
                           }
                         ],
                         "body": {
-                          "type": "CallExpression",
-                          "callee": {
-                            "type": "Identifier",
-                            "name": "compute"
-                          },
-                          "arguments": []
+                          "type": "ArrayExpression",
+                          "elements": [
+                            {
+                              "type": "CallExpression",
+                              "callee": {
+                                "type": "Identifier",
+                                "name": "compute",
+                                "nextParams": []
+                              },
+                              "arguments": []
+                            }
+                          ]
                         },
                         "generator": false,
                         "expression": true
@@ -476,7 +322,7 @@
                   },
                   "property": {
                     "type": "Identifier",
-                    "name": "map"
+                    "name": "bind"
                   }
                 },
                 "arguments": [
@@ -493,8 +339,12 @@
                       "type": "ArrayExpression",
                       "elements": [
                         {
-                          "type": "Identifier",
-                          "name": "c"
+                          "type": "CallExpression",
+                          "callee": {
+                            "type": "Identifier",
+                            "name": "compute"
+                          },
+                          "arguments": []
                         }
                       ]
                     },


### PR DESCRIPTION
- Generated `js` code now has only `bind` and `then` for `do` blocks unless
   there's a `return` statement in which case it is a `map`
- `maybe<Val>` is now a macro which expands to `if` statements in generated
   JavaScript