### PR TITLE
Fix calls to lambda Expressions

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -689,7 +689,7 @@ const ioParser = input => maybe(
 )
 /* IO ends here */
 
-const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaParser, lambdaCallParser,
+const expressionParser = input => parser.any(parenthesesParser, unaryExprParser, lambdaCallParser, lambdaParser,
                                              letExpressionParser, ifExprParser, memberExprParser, arrayParser,
                                              objectParser, booleanParser, nonReservedIdParser, numberParser,
                                              nullParser, stringParser, regexParser)(input)
@@ -702,7 +702,7 @@ const parenthesesParser = input => maybe(
   }
 )
 
-const valueParser = input => parser.any(binaryExprParser, fnCallParser, expressionParser)(input)
+const valueParser = input => parser.any(binaryExprParser, fnCallParser, lambdaCallParser, expressionParser)(input)
 
 const declParser = input => maybe(
   parser.all(nonReservedIdParser, equalSignParser, valueParser)(input),


### PR DESCRIPTION
- Move lamdaCallParser before lambdaParser in the expressionParser
- Add lambdaCallParser to valueParser