### PR TITLE
Allow whitespaces to exist before '\n' in returnParser

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -16,7 +16,7 @@ const {
 
 /*  Predefined regexes */
 const spaceRegex = () => /^([ \t]+)((.|\n)*)$/
-const returnRegex = () => /^(\n)((.|\n)*)$/
+const returnRegex = () => /^(\s*\n)((.|\n)*)$/
 const idRegex = () => /^([_a-zA-Z]+[a-zA-Z0-9_]*)((.|\n)*)$/
 const numRegex = () => /^((?:\d+(?:\.\d*)?|\.\d+)(?:[e][+-]?\d+)?)((.|\n)*)$/
 const boolRegex = () => /^(true|false)((.|\n)*)$/

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "author": "Santosh Rajan",
   "license": "MIT",
   "dependencies": {
-    "chokidar": "^1.6.1",
-    "escodegen": "^1.8.1",
-    "yargs": "^7.0.1"
+    "chokidar": "^1.7.0",
+    "escodegen": "^1.9.0",
+    "yargs": "^9.0.1"
   },
   "devDependencies": {
-    "ava": "^0.19.0",
-    "nyc": "^10.2.0"
+    "ava": "^0.22.0",
+    "nyc": "^11.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Trailing whitespaces are hard to detect for beginners and the 'syntax error' message is confusing. So, I think they should be parsed by the returnParser just like most other languages instead of giving a 'syntax error'. 