### PR TITLE
Add some basic support for inline comments

### DIFF
--- a/lib/basicParsers.js
+++ b/lib/basicParsers.js
@@ -16,7 +16,7 @@ const {
 
 /*  Predefined regexes */
 const spaceRegex = () => /^([ \t]+)((.|\n)*)$/
-const returnRegex = () => /^([ \t]*\n)((.|\n)*)$/
+const returnRegex = () => /^((?:\/\/.*)?[ \t]*\n)((.|\n)*)$/ // consume inline comment if any
 const idRegex = () => /^([_a-zA-Z]+[a-zA-Z0-9_]*)((.|\n)*)$/
 const numRegex = () => /^((?:\d+(?:\.\d*)?|\.\d+)(?:[e][+-]?\d+)?)((.|\n)*)$/
 const boolRegex = () => /^(true|false)((.|\n)*)$/

--- a/test/assert/withComment.json
+++ b/test/assert/withComment.json
@@ -62,7 +62,7 @@
           "type": "Line",
           "value": " This is a comment to test\n",
           "cursorLoc": {
-            "line": 6,
+            "line": 8,
             "column": 0
           }
         }
@@ -96,7 +96,17 @@
           }
         }
       ],
-      "kind": "const"
+      "kind": "const",
+      "leadingComments": [
+        {
+          "type": "Line",
+          "value": " this is an inline comment\n",
+          "cursorLoc": {
+            "line": 10,
+            "column": 0
+          }
+        }
+      ]
     },
     {
       "type": "VariableDeclaration",
@@ -147,17 +157,71 @@
           "type": "Block",
           "value": "\n\nMulti line comments\nMore comments\nEven more 2 + 1\n\nprod a b = a * b\n\n\n",
           "cursorLoc": {
-            "line": 20,
+            "line": 22,
             "column": 0
           }
         }
-      ],
+      ]
+    },
+    {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "CallExpression",
+        "callee": {
+          "type": "MemberExpression",
+          "computed": false,
+          "object": {
+            "type": "CallExpression",
+            "callee": {
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "type": "Identifier",
+                "name": "IO"
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "putLine"
+              }
+            },
+            "arguments": [
+              {
+                "type": "Literal",
+                "value": "testing inline comment inside \"do\"",
+                "raw": "testing inline comment inside \"do\"",
+                "sType": "string"
+              }
+            ],
+            "nextParams": [],
+            "sType": "IO"
+          },
+          "property": {
+            "type": "Identifier",
+            "name": "then"
+          }
+        },
+        "arguments": [
+          {
+            "type": "ArrowFunctionExpression",
+            "id": null,
+            "params": [],
+            "body": {
+              "type": "ArrayExpression",
+              "elements": []
+            },
+            "generator": false,
+            "expression": true
+          }
+        ],
+        "ioParams": [],
+        "sType": "IO"
+      },
       "trailingComments": [
         {
           "type": "Line",
           "value": " This is the end\n",
           "cursorLoc": {
-            "line": 25,
+            "line": 30,
             "column": 0
           }
         }

--- a/test/src/withComment.cl
+++ b/test/src/withComment.cl
@@ -1,10 +1,12 @@
+include node-core
+
 a = 15
 
 b = 64
 
 // This is a comment to test
 
-f = 1.58e-5
+f = 1.58e-5  // this is an inline comment
 
 m = 1 + 48
 
@@ -20,5 +22,8 @@ prod a b = a * b
 */
 
 variable = if 'hello' > 'world' then true else false
+
+do
+    putLine 'testing inline comment inside "do"'  // inside do
 
 // This is the end


### PR DESCRIPTION
I made returnParser parse inline comments. This is the simplest way to support inline comments since they always occur (optionally) before a return.

Currently, inline comments do not appear in the compiled js.