### PR TITLE
test files only if they have '.cl' extension

### DIFF
--- a/test/sourceFiles.test.js
+++ b/test/sourceFiles.test.js
@@ -32,10 +32,10 @@ const searchAndTest = (tests, assert) => {
   if (fs.existsSync(tests)) {
     fs.readdirSync(tests).forEach(function (file, index) {
       const curPath = path.join(tests, '/', file)
+      const pathParse = path.parse(curPath)
       if (fs.lstatSync(curPath).isDirectory()) {
         searchAndTest(curPath, path.join(assert, '/', file))
-      } else {
-        const pathParse = path.parse(curPath)
+      } else if (pathParse.ext === '.cl') {
         const input = initObj(readFileContent(path.join(pathParse.dir, `${pathParse.name}.cl`)))
         const assertJson = path.join(assert, `${pathParse.name}.json`)
         const jsonValue = require(assertJson)


### PR DESCRIPTION
This is useful because if we run any file inside /test/src/ a javascript file is generated and for the tests to pass again, we need to delete all the js files.