### PR TITLE
Static pattern matching

### DIFF
--- a/lib/astupdate.js
+++ b/lib/astupdate.js
@@ -68,6 +68,21 @@ const formMultiPatternAst = (funcdecl, patterndecls) => {
   return funcdecl
 }
 
+const formStaticPatternAst = (patterndecls) => {
+  const funcdeclbody = { type: 'BlockStatement', body: [] }
+  const blockstmtbody = { type: 'SwitchStatement', cases: [] }
+  const [cases] = buildExplicitCases(patterndecls)
+  blockstmtbody.cases = cases
+  const param = estemplate.identifier('x')
+  blockstmtbody.discriminant = param
+  funcdeclbody.body.push(blockstmtbody)
+  return estemplate.funcDeclaration(
+    estemplate.identifier(functionName(patterndecls[0])),
+    [param],
+    funcdeclbody
+  )
+}
+
 const isArrowFuncDecl = (decl) => {
   const declarations = decl.declarations
 
@@ -97,6 +112,13 @@ const isFunction = (decl) => {
   return isFunc
 }
 
+const functionName = (decl = {}) => {
+  const declarations = decl.declarations || null
+  if (!declarations) return null
+  const name = declarations[0].id.name
+  return name
+}
+
 const formFunctionAst = (funcdecl, patterndecls) => {
   const patternscount = patterndecls.length
   return patternscount === 0
@@ -104,13 +126,21 @@ const formFunctionAst = (funcdecl, patterndecls) => {
     : formMultiPatternAst(funcdecl, patterndecls)
 }
 
-const processSubTree = (decl) => {
+const processSubTree = (decl, nextDecl) => {
   if (isArrowFuncDecl(decl)) {
     if (isFunction(decl)) {
       // function declarations
-      const funcast = formFunctionAst(decl, patterns)
+      const funcAst = formFunctionAst(decl, patterns)
       patterns = []
-      return funcast
+      return funcAst
+    } else if (patterns.length > 0 &&
+      (!nextDecl || functionName(nextDecl) !== functionName(patterns[0]))
+    ) {
+      // static patten matching without variable
+      patterns.push(decl)
+      const patternFuncAst = formStaticPatternAst(patterns)
+      patterns = []
+      return patternFuncAst
     } else {
       // pattern matched function declarations
       patterns.push(decl)
@@ -123,8 +153,9 @@ const processSubTree = (decl) => {
 const updateAst = (ast) => {
   let newBody = []
   const declarations = ast.body
-  declarations.forEach((decl) => {
-    const subtree = processSubTree(decl)
+  declarations.forEach((decl, i) => {
+    const nextDecl = declarations[i + 1] || null
+    const subtree = processSubTree(decl, nextDecl)
     if (subtree !== null) newBody.push(subtree)
   })
   newBody = updateComment(newBody)

--- a/lib/astupdate.js
+++ b/lib/astupdate.js
@@ -44,42 +44,42 @@ const buildDefaultCase = (funcdecl) => {
   return defaultcase
 }
 
-const formMultiPatternAst = (funcdecl, patterndecls) => {
-  const funcdeclbody = { type: 'BlockStatement', body: [] }
-  const blockstmtbody = { type: 'SwitchStatement', cases: [] }
-  const [cases, flag] = buildExplicitCases(patterndecls)
-  const testTempl = funcdecl.declarations[0].init.params[0]
-  blockstmtbody.discriminant = testTempl
+const formMultiPatternAst = (funcDecl, patternDecls) => {
+  const funcDeclBody = { type: 'BlockStatement', body: [] }
+  const blockStmtBody = { type: 'SwitchStatement', cases: [] }
+  const [cases, flag] = buildExplicitCases(patternDecls)
+  const testTempl = funcDecl.declarations[0].init.params[0]
+  blockStmtBody.discriminant = testTempl
   if (flag === true) {
     const lengthTempl = estemplate.identifier('length')
-    blockstmtbody.discriminant = estemplate.memberExpression(
+    blockStmtBody.discriminant = estemplate.memberExpression(
       testTempl,
       lengthTempl
     ).expression
   }
-  cases.push(buildDefaultCase(funcdecl))
-  blockstmtbody.cases = cases
+  cases.push(buildDefaultCase(funcDecl))
+  blockStmtBody.cases = cases
 
-  funcdeclbody.body.push(blockstmtbody)
+  funcDeclBody.body.push(blockStmtBody)
 
-  funcdecl.declarations[0].init.body = funcdeclbody
-  funcdecl.declarations[0].init.expression = false
+  funcDecl.declarations[0].init.body = funcDeclBody
+  funcDecl.declarations[0].init.expression = false
 
-  return funcdecl
+  return funcDecl
 }
 
-const formStaticPatternAst = (patterndecls) => {
-  const funcdeclbody = { type: 'BlockStatement', body: [] }
-  const blockstmtbody = { type: 'SwitchStatement', cases: [] }
-  const [cases] = buildExplicitCases(patterndecls)
-  blockstmtbody.cases = cases
+const formStaticPatternAst = (patternDecls) => {
+  const funcDeclBody = { type: 'BlockStatement', body: [] }
+  const blockStmtBody = { type: 'SwitchStatement', cases: [] }
+  const [cases] = buildExplicitCases(patternDecls)
+  blockStmtBody.cases = cases
   const param = estemplate.identifier('x')
-  blockstmtbody.discriminant = param
-  funcdeclbody.body.push(blockstmtbody)
+  blockStmtBody.discriminant = param
+  funcDeclBody.body.push(blockStmtBody)
   return estemplate.funcDeclaration(
-    estemplate.identifier(functionName(patterndecls[0])),
+    estemplate.identifier(functionName(patternDecls[0])),
     [param],
-    funcdeclbody
+    funcDeclBody
   )
 }
 
@@ -119,11 +119,11 @@ const functionName = (decl = {}) => {
   return name
 }
 
-const formFunctionAst = (funcdecl, patterndecls) => {
-  const patternscount = patterndecls.length
-  return patternscount === 0
-    ? funcdecl
-    : formMultiPatternAst(funcdecl, patterndecls)
+const formFunctionAst = (funcDecl, patternDecls) => {
+  const patternsCount = patternDecls.length
+  return patternsCount === 0
+    ? funcDecl
+    : formMultiPatternAst(funcDecl, patternDecls)
 }
 
 const processSubTree = (decl, nextDecl) => {

--- a/lib/typeInference.js
+++ b/lib/typeInference.js
@@ -44,11 +44,11 @@ const unaryExprType = (expr) => {
 const getType = (expr, expectedType, localTypeObj, id) => {
   if (expr !== undefined) {
     const type = exprType(expr, localTypeObj, id)
-    return type === expectedType || expectedType === 'bool'
+    return type === expectedType ||
+      expectedType === 'bool' ||
+      type === 'needsInference'
       ? type
-      : type === 'needsInference'
-        ? type
-        : null
+      : null
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   },
   "lint-staged": {
     "**/*.+(js)": [
-      "standard --fix",
-      "git add ."
+      "standard --fix"
     ]
   },
   "author": "Santosh Rajan",

--- a/test/assert/staticPatternMatching.json
+++ b/test/assert/staticPatternMatching.json
@@ -1,0 +1,69 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "id": {
+            "type": "Identifier",
+            "name": "bobAt10"
+          },
+          "init": {
+            "type": "Literal",
+            "value": "naughty",
+            "raw": "naughty",
+            "sType": "string"
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "id": {
+            "type": "Identifier",
+            "name": "bobAt20"
+          },
+          "init": {
+            "type": "Literal",
+            "value": "nerdy",
+            "raw": "nerdy",
+            "sType": "string"
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "CallExpression",
+        "callee": {
+          "type": "MemberExpression",
+          "computed": false,
+          "object": {
+            "type": "Identifier",
+            "name": "console"
+          },
+          "property": {
+            "type": "Identifier",
+            "name": "log"
+          }
+        },
+        "arguments": [
+          {
+            "type": "Identifier",
+            "name": "bobAt20"
+          }
+        ],
+        "sType": "IO"
+      }
+    }
+  ],
+  "sourceType": "script"
+}

--- a/test/assert/staticPatternMatching.json
+++ b/test/assert/staticPatternMatching.json
@@ -8,32 +8,73 @@
           "type": "VariableDeclarator",
           "id": {
             "type": "Identifier",
-            "name": "bobAt10"
+            "name": "bobAt"
           },
           "init": {
-            "type": "Literal",
-            "value": "naughty",
-            "raw": "naughty",
-            "sType": "string"
-          }
-        }
-      ],
-      "kind": "const"
-    },
-    {
-      "type": "VariableDeclaration",
-      "declarations": [
-        {
-          "type": "VariableDeclarator",
-          "id": {
-            "type": "Identifier",
-            "name": "bobAt20"
-          },
-          "init": {
-            "type": "Literal",
-            "value": "nerdy",
-            "raw": "nerdy",
-            "sType": "string"
+            "type": "ArrowFunctionExpression",
+            "id": null,
+            "params": [
+              {
+                "type": "Identifier",
+                "name": "x"
+              }
+            ],
+            "body": {
+              "type": "BlockStatement",
+              "body": [
+                {
+                  "type": "SwitchStatement",
+                  "discriminant": {
+                    "type": "Identifier",
+                    "name": "x"
+                  },
+                  "cases": [
+                    {
+                      "type": "SwitchCase",
+                      "test": {
+                        "type": "Literal",
+                        "value": 10,
+                        "raw": "10",
+                        "sType": "number"
+                      },
+                      "consequent": [
+                        {
+                          "type": "ReturnStatement",
+                          "argument": {
+                            "type": "Literal",
+                            "value": "naughty",
+                            "raw": "naughty",
+                            "sType": "string"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SwitchCase",
+                      "test": {
+                        "type": "Literal",
+                        "value": 20,
+                        "raw": "20",
+                        "sType": "number"
+                      },
+                      "consequent": [
+                        {
+                          "type": "ReturnStatement",
+                          "argument": {
+                            "type": "Literal",
+                            "value": "nerdy",
+                            "raw": "nerdy",
+                            "sType": "string"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "generator": false,
+            "expression": false
           }
         }
       ],
@@ -42,6 +83,7 @@
     {
       "type": "ExpressionStatement",
       "expression": {
+        "sType": "IO",
         "type": "CallExpression",
         "callee": {
           "type": "MemberExpression",
@@ -57,11 +99,21 @@
         },
         "arguments": [
           {
-            "type": "Identifier",
-            "name": "bobAt20"
+            "type": "CallExpression",
+            "callee": {
+              "type": "Identifier",
+              "name": "bobAt"
+            },
+            "arguments": [
+              {
+                "type": "Literal",
+                "value": 20,
+                "raw": "20",
+                "sType": "number"
+              }
+            ]
           }
-        ],
-        "sType": "IO"
+        ]
       }
     }
   ],

--- a/test/src/staticPatternMatching.cl
+++ b/test/src/staticPatternMatching.cl
@@ -1,0 +1,5 @@
+
+bobAt10 = 'naughty'
+bobAt20 = 'nerdy'
+
+print bobAt20

--- a/test/src/staticPatternMatching.cl
+++ b/test/src/staticPatternMatching.cl
@@ -1,5 +1,5 @@
+bobAt 10 = 'naughty'
+bobAt 20 = 'nerdy'
 
-bobAt10 = 'naughty'
-bobAt20 = 'nerdy'
+print (bobAt 20)
 
-print bobAt20


### PR DESCRIPTION
Implements static pattern matching, without variable, like
```
bobAt 10 = 'naughty'
bobAt 20 = 'nerdy'
```

Present, it won't get parsed. Js file will be empty.

Fixes #188 